### PR TITLE
🛡️ Sentinel: Prevent default admin password in production

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The authentication system contained a hardcoded admin user (`admin@example.com`) initialized by default in the in-memory store, intended for testing but active in production.
 **Learning:** Developers often add "temporary" or "convenience" users for local testing but forget to wrap them in environment checks, creating critical backdoors.
 **Prevention:** Always wrap test data initialization in strict `process.env.NODE_ENV !== 'production'` checks, or better yet, use separate seed scripts/fixtures that are never imported in production code.
+
+## 2026-02-26 - Default Admin Configuration Bypass in Production
+**Vulnerability:** The `env.ts` validation schema allowed `ENABLE_DEFAULT_ADMIN=true` in production with the default password `admin123`. While the code checked for insecure `JWT_SECRET`, it missed checking the default admin password when enabled.
+**Learning:** Environment validation often focuses on *missing* variables (like `JWT_SECRET`) but neglects *insecure combinations* of valid variables (like enabling admin with default credentials).
+**Prevention:** Always validate sensitive configuration *values* (especially defaults) against environment contexts (production vs dev) using explicit logic checks or schema refinements to reject insecure defaults in production.

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル

--- a/trading-platform/app/lib/__tests__/env-admin-security.test.ts
+++ b/trading-platform/app/lib/__tests__/env-admin-security.test.ts
@@ -1,0 +1,55 @@
+
+describe('Admin Security Configuration', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    // Set a valid JWT_SECRET to bypass the existing check
+    process.env.JWT_SECRET = 'secure-secret-that-is-very-long-and-random-32-chars';
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should throw an error in production if ENABLE_DEFAULT_ADMIN is true and DEFAULT_ADMIN_PASSWORD is default (admin123)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ENABLE_DEFAULT_ADMIN = 'true';
+    process.env.DEFAULT_ADMIN_PASSWORD = 'admin123'; // or undefined, as it defaults to 'admin123'
+
+    expect(() => {
+      jest.requireActual('../env');
+    }).toThrow(/running in production with default admin credentials/);
+  });
+
+  it('should NOT throw an error in production if ENABLE_DEFAULT_ADMIN is true and DEFAULT_ADMIN_PASSWORD is secure', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ENABLE_DEFAULT_ADMIN = 'true';
+    process.env.DEFAULT_ADMIN_PASSWORD = 'very-secure-password-12345';
+
+    expect(() => {
+      jest.requireActual('../env');
+    }).not.toThrow();
+  });
+
+  it('should NOT throw an error in production if ENABLE_DEFAULT_ADMIN is false (even with default password)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ENABLE_DEFAULT_ADMIN = 'false';
+    process.env.DEFAULT_ADMIN_PASSWORD = 'admin123';
+
+    expect(() => {
+      jest.requireActual('../env');
+    }).not.toThrow();
+  });
+
+  it('should NOT throw an error in development (even with default password and admin enabled)', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.ENABLE_DEFAULT_ADMIN = 'true';
+    process.env.DEFAULT_ADMIN_PASSWORD = 'admin123';
+
+    expect(() => {
+      jest.requireActual('../env');
+    }).not.toThrow();
+  });
+});

--- a/trading-platform/app/lib/env.ts
+++ b/trading-platform/app/lib/env.ts
@@ -52,9 +52,17 @@ if (!parsed.success) {
     throw new Error('Invalid environment variables');
   }
 } else {
-  // Security Check: Ensure production uses a secure secret
-  if (parsed.data.NODE_ENV === 'production' && parsed.data.JWT_SECRET === DEFAULT_JWT_SECRET) {
-    throw new Error('CRITICAL SECURITY ERROR: You are running in production with the default JWT_SECRET. Please set a secure JWT_SECRET environment variable.');
+  // Security Check: Ensure production uses secure configuration
+  if (parsed.data.NODE_ENV === 'production') {
+    // 1. JWT Secret Check
+    if (parsed.data.JWT_SECRET === DEFAULT_JWT_SECRET) {
+      throw new Error('CRITICAL SECURITY ERROR: You are running in production with the default JWT_SECRET. Please set a secure JWT_SECRET environment variable.');
+    }
+
+    // 2. Default Admin Password Check
+    if (parsed.data.ENABLE_DEFAULT_ADMIN && parsed.data.DEFAULT_ADMIN_PASSWORD === 'admin123') {
+      throw new Error('CRITICAL SECURITY ERROR: You are running in production with default admin credentials (admin123). Please set a secure DEFAULT_ADMIN_PASSWORD or disable ENABLE_DEFAULT_ADMIN.');
+    }
   }
 }
 


### PR DESCRIPTION
This PR addresses a critical configuration vulnerability where the application could be deployed in production with the default admin password (`admin123`).

**Changes:**
1.  **Environment Validation:** Modified `trading-platform/app/lib/env.ts` to explicitly check for the insecure combination of `NODE_ENV=production`, `ENABLE_DEFAULT_ADMIN=true`, and `DEFAULT_ADMIN_PASSWORD='admin123'`. It now throws a critical error if detected.
2.  **Testing:** Added a new test file `trading-platform/app/lib/__tests__/env-admin-security.test.ts` that verifies:
    *   Error is thrown in production with default credentials.
    *   No error is thrown if a secure password is set.
    *   No error is thrown if admin is disabled.
    *   No error is thrown in development.

**Verification:**
*   `pnpm test app/lib/__tests__/env-admin-security.test.ts` passes.
*   Existing `pnpm test app/lib/__tests__/env-security.test.ts` passes.
*   Linting passes on modified files.

---
*PR created automatically by Jules for task [17618931530580673754](https://jules.google.com/task/17618931530580673754) started by @kaenozu*