### PR TITLE
🎨 Palette: Enhance OrderPanel Quantity Input with Stepper Control

### DIFF
--- a/trading-platform/app/components/OrderPanel.tsx
+++ b/trading-platform/app/components/OrderPanel.tsx
@@ -6,6 +6,7 @@ import { useOrderEntry } from '@/app/hooks/useOrderEntry';
 import { RiskSettingsPanel } from './RiskSettingsPanel';
 import { usePortfolioStore } from '@/app/store/portfolioStore';
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { Minus, Plus } from 'lucide-react';
 
 /**
  * メッセージ定数
@@ -243,14 +244,6 @@ export function OrderPanel({ stock, currentPrice, ohlcv = [] }: OrderPanelProps)
           <div className="flex gap-2">
             <button
               type="button"
-              onClick={() => setQuantity(Math.max(1, quantity + 1))}
-              className="text-[10px] text-[#92adc9] hover:text-white bg-[#233648] px-1.5 rounded transition-colors"
-              aria-label="数量を1増やす"
-            >
-              +1
-            </button>
-            <button
-              type="button"
               onClick={() => setQuantity(Math.max(1, quantity + 100))}
               className="text-[10px] text-[#92adc9] hover:text-white bg-[#233648] px-1.5 rounded transition-colors"
               aria-label="数量を100増やす"
@@ -266,19 +259,38 @@ export function OrderPanel({ stock, currentPrice, ohlcv = [] }: OrderPanelProps)
             )}
           </div>
         </div>
-        <input
-          id={ids.quantity}
-          type="number"
-          min="1"
-          step="1"
-          inputMode="numeric"
-          pattern="[0-9]*"
-          autoComplete="off"
-          value={quantity}
-          onFocus={(e) => e.target.select()}
-          onChange={(e) => setQuantity(Math.max(1, parseInt(e.target.value) || 0))}
-          className="bg-[#192633] border border-[#233648] rounded text-white text-sm p-2 outline-none focus:border-primary"
-        />
+        <div className="flex items-center">
+          <button
+            type="button"
+            onClick={() => setQuantity(Math.max(1, quantity - 1))}
+            className="bg-[#233648] hover:bg-[#324d67] border border-[#233648] text-white p-2 rounded-l transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:z-10"
+            disabled={quantity <= 1}
+            aria-label="数量を減らす"
+          >
+            <Minus size={16} />
+          </button>
+          <input
+            id={ids.quantity}
+            type="number"
+            min="1"
+            step="1"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            autoComplete="off"
+            value={quantity}
+            onFocus={(e) => e.target.select()}
+            onChange={(e) => setQuantity(Math.max(1, parseInt(e.target.value) || 0))}
+            className="flex-1 bg-[#192633] border-y border-[#233648] text-white text-sm p-2 text-center outline-none focus:border-primary focus:z-10"
+          />
+          <button
+            type="button"
+            onClick={() => setQuantity(Math.max(1, quantity + 1))}
+            className="bg-[#233648] hover:bg-[#324d67] border border-[#233648] text-white p-2 rounded-r transition-colors focus:z-10"
+            aria-label="数量を増やす"
+          >
+            <Plus size={16} />
+          </button>
+        </div>
       </div>
 
       {/* Limit Price (if LIMIT) */}

--- a/trading-platform/app/components/__tests__/OrderPanel_Stepper.test.tsx
+++ b/trading-platform/app/components/__tests__/OrderPanel_Stepper.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { OrderPanel } from '../OrderPanel';
+import { usePortfolioStore } from '@/app/store/portfolioStore';
+
+jest.mock('@/app/store/portfolioStore');
+
+// Mock ResizeObserver
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+}));
+
+describe('OrderPanel Quantity Stepper', () => {
+    const mockStock = {
+        symbol: '7203',
+        name: 'Toyota',
+        price: 2000,
+        change: 0,
+        changePercent: 0,
+        market: 'japan' as const,
+        sector: 'Automotive',
+        volume: 1000000
+    };
+
+    const mockExecuteOrder = jest.fn();
+
+    const mockStoreState = {
+        portfolio: { cash: 1000000, positions: [] },
+        executeOrder: mockExecuteOrder,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (usePortfolioStore as unknown as jest.Mock).mockImplementation((selector) => {
+            return selector ? selector(mockStoreState) : mockStoreState;
+        });
+    });
+
+    it('should increment quantity when plus button is clicked', () => {
+        render(<OrderPanel stock={mockStock} currentPrice={2000} />);
+
+        const input = screen.getByLabelText('数量');
+        const plusButton = screen.getByRole('button', { name: '数量を増やす' });
+
+        expect(input).toHaveValue(1); // Default value
+
+        fireEvent.click(plusButton);
+        expect(input).toHaveValue(2);
+
+        fireEvent.click(plusButton);
+        expect(input).toHaveValue(3);
+    });
+
+    it('should decrement quantity when minus button is clicked', () => {
+        render(<OrderPanel stock={mockStock} currentPrice={2000} />);
+
+        const input = screen.getByLabelText('数量');
+        const plusButton = screen.getByRole('button', { name: '数量を増やす' });
+        const minusButton = screen.getByRole('button', { name: '数量を減らす' });
+
+        // Increase first
+        fireEvent.click(plusButton);
+        fireEvent.click(plusButton);
+        expect(input).toHaveValue(3);
+
+        // Decrease
+        fireEvent.click(minusButton);
+        expect(input).toHaveValue(2);
+    });
+
+    it('should not decrement below 1', () => {
+        render(<OrderPanel stock={mockStock} currentPrice={2000} />);
+
+        const input = screen.getByLabelText('数量');
+        const minusButton = screen.getByRole('button', { name: '数量を減らす' });
+
+        expect(input).toHaveValue(1);
+        expect(minusButton).toBeDisabled();
+
+        fireEvent.click(minusButton);
+        expect(input).toHaveValue(1);
+    });
+
+    it('should allow typing quantity directly', () => {
+        render(<OrderPanel stock={mockStock} currentPrice={2000} />);
+
+        const input = screen.getByLabelText('数量');
+
+        fireEvent.change(input, { target: { value: '50' } });
+        expect(input).toHaveValue(50);
+
+        // Ensure stepper works after manual input
+        const plusButton = screen.getByRole('button', { name: '数量を増やす' });
+        fireEvent.click(plusButton);
+        expect(input).toHaveValue(51);
+    });
+
+    it('should respect +100 button functionality', () => {
+        render(<OrderPanel stock={mockStock} currentPrice={2000} />);
+
+        const input = screen.getByLabelText('数量');
+        const plus100Button = screen.getByRole('button', { name: '数量を100増やす' });
+
+        fireEvent.click(plus100Button);
+        expect(input).toHaveValue(101);
+    });
+});

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル


### PR DESCRIPTION
Enhanced the OrderPanel quantity input by replacing the simple +1 button with a fully functional stepper control (decrement/increment). This improves usability for fine-grained adjustments and aligns with standard UI patterns.

- Added Minus/Plus icons from `lucide-react`.
- Implemented decrement logic (min value 1).
- Grouped input and buttons visually.
- Moved +100 and Max buttons to a secondary row/position.
- Added ARIA labels for accessibility.
- Validated with new unit tests in `OrderPanel_Stepper.test.tsx`.


---
*PR created automatically by Jules for task [1921623764497391795](https://jules.google.com/task/1921623764497391795) started by @kaenozu*