### PR TITLE
Refactor prediction worker to remove stubs

### DIFF
--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -9,7 +9,7 @@ import { Stock, Signal, OHLCV } from '@/app/types';
 
 /**
  * 成功体験デモページ (Sato-san Scenario)
- * 初心者がこのアプリを使って利益を出すまでの一連の流れを可視化します。
+ * 初心者がこのアプリを開いて利益を出すまでの一連の流れを可視化します。
  */
 export default function DemoPage() {
   // 1. デモ用の銘柄データ (トヨタ自動車)
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル

--- a/trading-platform/app/lib/services/enhanced-prediction-service.ts
+++ b/trading-platform/app/lib/services/enhanced-prediction-service.ts
@@ -158,18 +158,22 @@ export class EnhancedPredictionService {
       // Get optimized weights for regime
       const weights = OPTIMIZED_REGIME_WEIGHTS[regime];
 
+      // Calculate pattern features on Main Thread (lightweight enough)
+      const patternFeatures = candlestickPatternService.calculatePatternFeatures(data);
+      const patternSignal = candlestickPatternService.getPatternSignal(patternFeatures);
+
       let result: Omit<EnhancedPredictionResult, 'marketRegime' | 'calculationTime'>;
 
       // Try to use web worker first
       if (this.useWorker) {
         try {
-          result = await this.predictWithWorker(symbol, data, indicators);
+          result = await this.predictWithWorker(symbol, data, indicators, patternFeatures, patternSignal, weights);
         } catch (error) {
           devWarn('Worker prediction failed, falling back to main thread:', error);
-          result = await this.predictOnMainThread(symbol, data, indicators, weights);
+          result = await this.predictOnMainThread(symbol, data, indicators, weights, patternFeatures, patternSignal);
         }
       } else {
-        result = await this.predictOnMainThread(symbol, data, indicators, weights);
+        result = await this.predictOnMainThread(symbol, data, indicators, weights, patternFeatures, patternSignal);
       }
 
       const finalResult: EnhancedPredictionResult = {
@@ -221,7 +225,10 @@ export class EnhancedPredictionService {
   private async predictWithWorker(
     symbol: string, 
     data: OHLCV[], 
-    indicators?: TechnicalIndicatorsWithATR
+    indicators: TechnicalIndicatorsWithATR | undefined,
+    patternFeatures: PatternFeatures,
+    patternSignal: number,
+    weights: { RF: number; XGB: number; LSTM: number; TECHNICAL: number }
   ): Promise<Omit<EnhancedPredictionResult, 'marketRegime' | 'calculationTime'>> {
     const request: PredictionRequest = {
       id: `pred_${Date.now()}_${symbol}`,
@@ -241,10 +248,22 @@ export class EnhancedPredictionService {
           lower: indicators.bollingerBands?.lower || []
         },
         atr: indicators.atr || []
-      } : undefined
+      } : undefined,
+      patternFeatures,
+      patternSignal,
+      weights
     };
 
     const result = await predictionWorker.predict(request);
+
+    // Calculate normalized weights for contribution breakdown
+    const totalWeight = weights.RF + weights.XGB + weights.LSTM + weights.TECHNICAL;
+    const normalizedWeights = {
+      RF: weights.RF / totalWeight,
+      XGB: weights.XGB / totalWeight,
+      LSTM: weights.LSTM / totalWeight,
+      TECHNICAL: weights.TECHNICAL / totalWeight
+    };
 
     return {
       signal: result.signal,
@@ -252,19 +271,14 @@ export class EnhancedPredictionService {
       direction: result.expectedReturn > 0 ? 1 : -1,
       expectedReturn: result.expectedReturn,
       ensembleContribution: {
-        rf: 0.3, // Simplified for worker
-        xgb: 0.3,
-        lstm: 0.3,
-        pattern: 0.1
+        rf: (result.components?.rf || 0) * normalizedWeights.RF,
+        xgb: (result.components?.xgb || 0) * normalizedWeights.XGB,
+        lstm: (result.components?.lstm || 0) * normalizedWeights.LSTM,
+        pattern: patternSignal * normalizedWeights.TECHNICAL
       },
       features: {
         technical: result.features,
-        pattern: {
-          isDoji: 0, isHammer: 0, isInvertedHammer: 0, isShootingStar: 0,
-          isBullishEngulfing: 0, isBearishEngulfing: 0, isMorningStar: 0, isEveningStar: 0,
-          isPiercingLine: 0, isDarkCloudCover: 0, isBullishHarami: 0, isBearishHarami: 0,
-          bodyRatio: 0.5, upperShadowRatio: 0.25, lowerShadowRatio: 0.25, candleStrength: 0
-        }
+        pattern: result.patternFeatures || patternFeatures
       }
     };
   }
@@ -276,18 +290,20 @@ export class EnhancedPredictionService {
     symbol: string,
     data: OHLCV[],
     indicators: TechnicalIndicatorsWithATR | undefined,
-    weights: { RF: number; XGB: number; LSTM: number; TECHNICAL: number }
+    weights: { RF: number; XGB: number; LSTM: number; TECHNICAL: number },
+    patternFeatures: PatternFeatures,
+    patternSignal: number
   ): Promise<Omit<EnhancedPredictionResult, 'marketRegime' | 'calculationTime'>> {
     
     // Calculate features
     const features = featureEngineeringService.calculateBasicFeatures(data);
-    const patternFeatures = candlestickPatternService.calculatePatternFeatures(data);
+    // patternFeatures already calculated
 
     // Calculate model predictions
     const rf = this.calculator.calculateRandomForest(features);
     const xgb = this.calculator.calculateXGBoost(features);
     const lstm = this.calculator.calculateLSTM(features);
-    const patternSignal = candlestickPatternService.getPatternSignal(patternFeatures);
+    // patternSignal already calculated
 
     // Weighted ensemble
     const totalWeight = weights.RF + weights.XGB + weights.LSTM + weights.TECHNICAL;

--- a/trading-platform/app/lib/services/prediction-worker.ts
+++ b/trading-platform/app/lib/services/prediction-worker.ts
@@ -28,6 +28,14 @@ export interface PredictionRequest {
     bb: { upper: number[]; middle: number[]; lower: number[] };
     atr: number[];
   };
+  patternFeatures?: PatternFeatures;
+  patternSignal?: number;
+  weights?: {
+    RF: number;
+    XGB: number;
+    LSTM: number;
+    TECHNICAL: number;
+  };
 }
 
 export interface PredictionResult {
@@ -37,6 +45,12 @@ export interface PredictionResult {
   expectedReturn: number;
   duration: number;
   features: PredictionFeatures;
+  patternFeatures: PatternFeatures;
+  components: {
+    rf: number;
+    xgb: number;
+    lstm: number;
+  };
   ensembleWeights: {
     RF: number;
     XGB: number;
@@ -55,10 +69,10 @@ const workerCode = `
 // Robust prediction logic for web worker (Production implementation)
 
 self.onmessage = function(e) {
-  const { id, symbol, data, indicators } = e.data;
+  const { id, symbol, data, indicators, patternFeatures, patternSignal, weights } = e.data;
   
   try {
-    // Calculate features
+    // Calculate technical features
     const features = calculateFeatures(data, indicators);
     
     // Calculate predictions from each model (Algorithmic approximation)
@@ -66,16 +80,28 @@ self.onmessage = function(e) {
     const xgb = calculateXGB(features);
     const lstm = calculateLSTM(features);
     
+    // Use passed weights or defaults
+    const w = weights || { RF: 0.35, XGB: 0.35, LSTM: 0.30, TECHNICAL: 0 };
+
     // Ensemble with optimized weights
-    const weights = { RF: 0.35, XGB: 0.35, LSTM: 0.30 };
-    const ensemble = rf * weights.RF + xgb * weights.XGB + lstm * weights.LSTM;
+    // If patternSignal is provided, include it
+    const technicalComponent = (patternSignal || 0) * (w.TECHNICAL || 0);
+    const ensemble = rf * w.RF + xgb * w.XGB + lstm * w.LSTM + technicalComponent;
     
-    // Calculate confidence based on technical alignment
-    const confidence = calculateConfidence(features, ensemble);
+    // Calculate confidence based on technical alignment and pattern strength
+    const confidence = calculateConfidence(features, patternFeatures, ensemble);
     
     // Generate signal with dynamic price targets
     const signal = generateSignal(symbol, ensemble, confidence, data[data.length - 1]);
     
+    // Default pattern features if not provided (should be provided by main thread)
+    const finalPatternFeatures = patternFeatures || {
+      isDoji: 0, isHammer: 0, isInvertedHammer: 0, isShootingStar: 0,
+      isBullishEngulfing: 0, isBearishEngulfing: 0, isMorningStar: 0, isEveningStar: 0,
+      isPiercingLine: 0, isDarkCloudCover: 0, isBullishHarami: 0, isBearishHarami: 0,
+      bodyRatio: 0.5, upperShadowRatio: 0.25, lowerShadowRatio: 0.25, candleStrength: 0
+    };
+
     self.postMessage({
       id,
       signal,
@@ -83,7 +109,9 @@ self.onmessage = function(e) {
       expectedReturn: ensemble,
       duration: 5,
       features,
-      ensembleWeights: { ...weights, TECHNICAL: 0 }
+      patternFeatures: finalPatternFeatures,
+      components: { rf, xgb, lstm },
+      ensembleWeights: w
     });
   } catch (error) {
     self.postMessage({
@@ -135,11 +163,16 @@ function calculateLSTM(f) {
   return (f.priceMomentum * 0.6) + (f.macdSignal * 0.4);
 }
 
-function calculateConfidence(f, ensemble) {
+function calculateConfidence(f, patternFeatures, ensemble) {
   let conf = 0.5;
   if (f.rsi < 20 || f.rsi > 80) conf += 0.15;
   if (Math.abs(f.sma20) > 3) conf += 0.1;
   if (f.volumeRatio > 2) conf += 0.05;
+
+  if (patternFeatures && patternFeatures.candleStrength > 0.7) {
+    conf += 0.08;
+  }
+
   return Math.min(0.95, conf);
 }
 
@@ -232,7 +265,7 @@ export class PredictionWorker {
     const calculator = new PredictionCalculator();
     const featureService = featureEngineeringService;
 
-    const { symbol, data, indicators } = request;
+    const { symbol, data, indicators, weights: passedWeights, patternSignal: passedSignal } = request;
     const transformedIndicators = indicators ? {
       ...indicators,
       macd: {
@@ -246,20 +279,23 @@ export class PredictionWorker {
         lower: indicators.bb?.lower || []
       }
     } : undefined;
+
     const features = featureService.calculateBasicFeatures(data);
-    const patternFeatures = candlestickPatternService.calculatePatternFeatures(data);
+
+    // Use passed pattern features or calculate new ones
+    const patternFeatures = request.patternFeatures || candlestickPatternService.calculatePatternFeatures(data);
     
     // Calculate predictions
     const rf = calculator.calculateRandomForest(features);
     const xgb = calculator.calculateXGBoost(features);
     const lstm = calculator.calculateLSTM(features);
     
-    // Add pattern signal
-    const patternSignal = candlestickPatternService.getPatternSignal(patternFeatures);
+    // Add pattern signal (use passed or calculate)
+    const patternSignal = passedSignal !== undefined ? passedSignal : candlestickPatternService.getPatternSignal(patternFeatures);
     
     // Ensemble with pattern influence
-    const weights = { RF: 0.30, XGB: 0.30, LSTM: 0.30, PATTERN: 0.10 };
-    const ensemble = rf * weights.RF + xgb * weights.XGB + lstm * weights.LSTM + patternSignal * weights.PATTERN;
+    const weights = passedWeights || { RF: 0.30, XGB: 0.30, LSTM: 0.30, TECHNICAL: 0.10 };
+    const ensemble = rf * weights.RF + xgb * weights.XGB + lstm * weights.LSTM + patternSignal * weights.TECHNICAL;
     
     // Calculate confidence
     const confidence = this.calculateConfidence(features, patternFeatures, ensemble);
@@ -274,7 +310,9 @@ export class PredictionWorker {
       expectedReturn: Math.abs(ensemble),
       duration: ensemble > 0 ? 5 : -5,
       features,
-      ensembleWeights: { RF: weights.RF, XGB: weights.XGB, LSTM: weights.LSTM, TECHNICAL: weights.PATTERN }
+      patternFeatures,
+      components: { rf, xgb, lstm },
+      ensembleWeights: weights
     };
   }
 


### PR DESCRIPTION
Refactored the `EnhancedPredictionService` and `PredictionWorker` to address a divergence where the worker implementation returned hardcoded/stubbed pattern features and ensemble contributions.

Key changes:
- Moved `CandlestickPatternService` usage to the main thread in `EnhancedPredictionService`, calculating features before the worker fork.
- Updated `PredictionWorker` (inline code) to accept `patternFeatures`, `patternSignal`, and `weights` as inputs.
- Updated `PredictionWorker` to return the actual `patternFeatures` and a breakdown of model components (`rf`, `xgb`, `lstm`) in the result.
- Removed hardcoded stub values (`{ isDoji: 0, ... }`) from `predictWithWorker`.
- Updated `fallbackPredict` to maintain consistency with the new interface.

This ensures that predictions run via the worker (the default in browser environments) now return accurate, full-fidelity data consistent with the main-thread implementation.

---
*PR created automatically by Jules for task [12781206641077937795](https://jules.google.com/task/12781206641077937795) started by @kaenozu*