### PR TITLE
⚡ Bolt: Fix StockTable Polling Loop Performance

### DIFF
--- a/trading-platform/app/components/StockTable.tsx
+++ b/trading-platform/app/components/StockTable.tsx
@@ -176,6 +176,12 @@ export const StockTable = memo(({
   const removeFromWatchlist = useWatchlistStore(state => state.removeFromWatchlist);
   const [pollingInterval, setPollingInterval] = useState(60000);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const stocksRef = useRef(stocks);
+
+  // Update stocks ref when stocks change to avoid re-creating getAdaptiveInterval
+  useEffect(() => {
+    stocksRef.current = stocks;
+  }, [stocks]);
   
   // Sorting state
   const [sortField, setSortField] = useState<SortField>('symbol');
@@ -224,14 +230,15 @@ export const StockTable = memo(({
 
   // Adaptive polling interval based on market volatility
   const getAdaptiveInterval = useCallback(() => {
-    if (stocks.length === 0) return 60000;
+    const currentStocks = stocksRef.current;
+    if (currentStocks.length === 0) return 60000;
     
     // Calculate average volatility
     let totalVol = 0;
-    for (let i = 0; i < stocks.length; i++) {
-      totalVol += Math.abs(stocks[i].changePercent || 0);
+    for (let i = 0; i < currentStocks.length; i++) {
+      totalVol += Math.abs(currentStocks[i].changePercent || 0);
     }
-    const avgVol = totalVol / stocks.length;
+    const avgVol = totalVol / currentStocks.length;
     
     // Higher volatility -> Faster polling
     // > 2% avg move -> 15s
@@ -240,7 +247,7 @@ export const StockTable = memo(({
     if (avgVol > 2) return 15000;
     if (avgVol > 1) return 30000;
     return 60000;
-  }, [stocks]);
+  }, []); // No dependencies to prevent polling reset
 
   useEffect(() => {
     let mounted = true;

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル


### PR DESCRIPTION
⚡ Bolt: Fix Polling Loop Regression in StockTable

💡 What:
Introduced `stocksRef` (useRef) to hold the latest `stocks` data inside `StockTable`.
Updated `getAdaptiveInterval` to read from `stocksRef.current` instead of the `stocks` prop directly.
Removed `stocks` from `getAdaptiveInterval` dependency array.

🎯 Why:
The `getAdaptiveInterval` function depended on `stocks` to calculate volatility.
Every time a poll completed and updated `stocks` (prices changed), `getAdaptiveInterval` was recreated.
This caused the main `useEffect` (which depends on `getAdaptiveInterval`) to restart.
Restarting the effect triggers `fetchQuotes()` immediately, bypassing the intended `setTimeout` delay.
This resulted in a "polling storm" where the client fetched data as fast as the network allowed, ignoring the adaptive interval logic.

📊 Impact:
- Prevents unnecessary network request flooding (reduced from "max possible" to "adaptive interval").
- Reduces CPU usage by avoiding constant effect teardown/setup.
- Ensures the "Adaptive Interval" logic (15s/30s/60s) actually works.

🔬 Measurement:
Verified with a reproduction test case that confirms `fetchQuotes` is NOT called immediately upon prop update, whereas it was called immediately before the fix. Existing tests pass.

---
*PR created automatically by Jules for task [7609577976841919936](https://jules.google.com/task/7609577976841919936) started by @kaenozu*