### PR TITLE
🛡️ Sentinel: [HIGH] Prevent default admin password in production

### DIFF
--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル

--- a/trading-platform/app/lib/__tests__/env-admin-security.test.ts
+++ b/trading-platform/app/lib/__tests__/env-admin-security.test.ts
@@ -1,0 +1,46 @@
+
+describe('Environment Admin Security', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should throw an error in production if ENABLE_DEFAULT_ADMIN is true and DEFAULT_ADMIN_PASSWORD is default', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ENABLE_DEFAULT_ADMIN = 'true';
+    process.env.DEFAULT_ADMIN_PASSWORD = 'admin123';
+    process.env.JWT_SECRET = 'secure-secret-that-is-at-least-32-chars-long'; // To avoid JWT error
+
+    expect(() => {
+      jest.requireActual('../env');
+    }).toThrow('CRITICAL SECURITY ERROR: You are running in production with ENABLE_DEFAULT_ADMIN=true but using the default password (admin123). Please set a strong DEFAULT_ADMIN_PASSWORD environment variable.');
+  });
+
+  it('should NOT throw an error in production if ENABLE_DEFAULT_ADMIN is false', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ENABLE_DEFAULT_ADMIN = 'false';
+    process.env.DEFAULT_ADMIN_PASSWORD = 'admin123';
+    process.env.JWT_SECRET = 'secure-secret-that-is-at-least-32-chars-long';
+
+    expect(() => {
+      jest.requireActual('../env');
+    }).not.toThrow();
+  });
+
+  it('should NOT throw an error in production if ENABLE_DEFAULT_ADMIN is true and password is secure', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ENABLE_DEFAULT_ADMIN = 'true';
+    process.env.DEFAULT_ADMIN_PASSWORD = 'secure-password-changed';
+    process.env.JWT_SECRET = 'secure-secret-that-is-at-least-32-chars-long';
+
+    expect(() => {
+      jest.requireActual('../env');
+    }).not.toThrow();
+  });
+});

--- a/trading-platform/app/lib/env.ts
+++ b/trading-platform/app/lib/env.ts
@@ -56,6 +56,11 @@ if (!parsed.success) {
   if (parsed.data.NODE_ENV === 'production' && parsed.data.JWT_SECRET === DEFAULT_JWT_SECRET) {
     throw new Error('CRITICAL SECURITY ERROR: You are running in production with the default JWT_SECRET. Please set a secure JWT_SECRET environment variable.');
   }
+
+  // Security Check: Ensure production uses a secure admin password if default admin is enabled
+  if (parsed.data.NODE_ENV === 'production' && parsed.data.ENABLE_DEFAULT_ADMIN && parsed.data.DEFAULT_ADMIN_PASSWORD === 'admin123') {
+    throw new Error('CRITICAL SECURITY ERROR: You are running in production with ENABLE_DEFAULT_ADMIN=true but using the default password (admin123). Please set a strong DEFAULT_ADMIN_PASSWORD environment variable.');
+  }
 }
 
 export const env = parsed.success ? parsed.data : envSchema.parse({});


### PR DESCRIPTION
🛡️ Sentinel Security Enhancement: Prevent Insecure Default Admin Password

**🚨 Severity: HIGH**

**💡 Vulnerability:**
The application allows running in a `production` environment with `ENABLE_DEFAULT_ADMIN=true` while using the default, hardcoded password (`admin123`). This could lead to unauthorized administrative access if an operator enables the default admin feature but forgets to change the password.

**🎯 Impact:**
If exploited, an attacker could log in as the default admin user and gain full control over the application, including user management and system settings.

**🔧 Fix:**
Implemented a mandatory runtime check in `trading-platform/app/lib/env.ts`. The application now throws a critical error during startup if:
1. `NODE_ENV` is `production`
2. `ENABLE_DEFAULT_ADMIN` is `true`
3. `DEFAULT_ADMIN_PASSWORD` is set to the default value (`admin123`)

**✅ Verification:**
- Added a new test suite `trading-platform/app/lib/__tests__/env-admin-security.test.ts` which confirms that:
    - The application throws an error when misconfigured in production.
    - The application starts normally if `ENABLE_DEFAULT_ADMIN` is `false`.
    - The application starts normally if a secure password is provided.
- Ran existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [7142683937423448364](https://jules.google.com/task/7142683937423448364) started by @kaenozu*