### PR TITLE
⚡ Bolt: Optimize StockTable polling and fix performance monitor stability

### DIFF
--- a/trading-platform/app/components/StockTable.tsx
+++ b/trading-platform/app/components/StockTable.tsx
@@ -176,6 +176,11 @@ export const StockTable = memo(({
   const removeFromWatchlist = useWatchlistStore(state => state.removeFromWatchlist);
   const [pollingInterval, setPollingInterval] = useState(60000);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const stocksRef = useRef(stocks);
+
+  useEffect(() => {
+    stocksRef.current = stocks;
+  }, [stocks]);
   
   // Sorting state
   const [sortField, setSortField] = useState<SortField>('symbol');
@@ -224,14 +229,15 @@ export const StockTable = memo(({
 
   // Adaptive polling interval based on market volatility
   const getAdaptiveInterval = useCallback(() => {
-    if (stocks.length === 0) return 60000;
+    const currentStocks = stocksRef.current;
+    if (currentStocks.length === 0) return 60000;
     
     // Calculate average volatility
     let totalVol = 0;
-    for (let i = 0; i < stocks.length; i++) {
-      totalVol += Math.abs(stocks[i].changePercent || 0);
+    for (let i = 0; i < currentStocks.length; i++) {
+      totalVol += Math.abs(currentStocks[i].changePercent || 0);
     }
-    const avgVol = totalVol / stocks.length;
+    const avgVol = totalVol / currentStocks.length;
     
     // Higher volatility -> Faster polling
     // > 2% avg move -> 15s
@@ -240,7 +246,7 @@ export const StockTable = memo(({
     if (avgVol > 2) return 15000;
     if (avgVol > 1) return 30000;
     return 60000;
-  }, [stocks]);
+  }, []);
 
   useEffect(() => {
     let mounted = true;

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル

--- a/trading-platform/app/lib/performance/__tests__/monitor.test.ts
+++ b/trading-platform/app/lib/performance/__tests__/monitor.test.ts
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react';
+import { usePerformanceMonitor } from '../monitor';
+
+describe('usePerformanceMonitor', () => {
+  it('returns an object with measureAsync', () => {
+    const { result } = renderHook(() => usePerformanceMonitor('TestComponent'));
+
+    expect(result.current).toHaveProperty('measure');
+    expect(result.current).toHaveProperty('measureApi');
+    expect(result.current).toHaveProperty('measureAsync'); // Currently fails
+  });
+
+  it('returns a stable object reference', () => {
+    const { result, rerender } = renderHook(() => usePerformanceMonitor('TestComponent'));
+
+    const initialResult = result.current;
+    rerender();
+
+    expect(result.current).toBe(initialResult); // Currently fails
+  });
+});

--- a/trading-platform/app/lib/performance/monitor.ts
+++ b/trading-platform/app/lib/performance/monitor.ts
@@ -1,4 +1,6 @@
 import { logger } from '@/app/core/logger';
+import { useMemo } from 'react';
+
 /**
  * Performance Monitor
  * 
@@ -329,14 +331,21 @@ export const performanceMonitor = new PerformanceMonitor();
 
 // Export hook for React components
 export function usePerformanceMonitor(componentName: string) {
-  return {
+  return useMemo(() => ({
     measure: (callback: () => void) => {
       performanceMonitor.measureRender(componentName, callback);
     },
     measureApi: <T>(endpoint: string, callback: () => Promise<T>) => {
       return performanceMonitor.measureApiCall(`${componentName}.${endpoint}`, callback);
     },
-  };
+    measureAsync: <T>(
+      name: string,
+      callback: () => Promise<T>,
+      _context?: Record<string, unknown>
+    ) => {
+      return performanceMonitor.measureAsync(`${componentName}.${name}`, callback, _context);
+    },
+  }), [componentName]);
 }
 
 // Web Vitals tracking


### PR DESCRIPTION
*   💡 **What**:
    *   Optimized `StockTable` to use `useRef` for stock data access, decoupling polling logic from data updates.
    *   Fixed `usePerformanceMonitor` hook to return a stable (memoized) object and added missing `measureAsync` property.
    *   Added `monitor.test.ts` to verify hook stability and API completeness.
*   🎯 **Why**:
    *   `StockTable` was tearing down and recreating the polling interval on every price update, causing excessive overhead and potential "thrashing" of network requests.
    *   `usePerformanceMonitor` returned a new object on every render, forcing all consumers (like `StockTable`) to re-run effects dependent on it.
    *   `measureAsync` was missing from the hook return value, causing runtime crashes or unhandled promise rejections in `StockTable`.
*   📊 **Impact**:
    *   Eliminates unnecessary effect re-runs in `StockTable` (and other consumers of performance monitor).
    *   Ensures polling interval is respected and adaptive logic works correctly without resetting the timer.
    *   Prevents runtime errors when using `measureAsync`.
*   🔬 **Measurement**:
    *   `pnpm test app/lib/performance` passes (new test confirms stability).
    *   Verified via linting and code review.

---
*PR created automatically by Jules for task [2679733866831129651](https://jules.google.com/task/2679733866831129651) started by @kaenozu*