### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal sanitization bypass

### DIFF
--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル

--- a/trading-platform/app/lib/security/InputSanitizer.ts
+++ b/trading-platform/app/lib/security/InputSanitizer.ts
@@ -138,12 +138,14 @@ export function detectXss(input: string): boolean {
  */
 export function detectPathTraversal(input: string): boolean {
   const traversalPatterns = [
-    /\.\.\//,
-    /\.\.\\/,
-    /%2e%2e%2f/i,
-    /%2e%2e\//i,
-    /\.\.\/%2f/i,
-    /%252e%252e%252f/i,
+    /\.\.\//,        // ../
+    /\.\.\\/,        // ..\
+    /%2e%2e%2f/i,    // %2e%2e%2f
+    /%2e%2e\//i,     // %2e%2e/
+    /\.\.%2f/i,      // ..%2f
+    /\.\.%5c/i,      // ..%5c
+    /%2e%2e%5c/i,    // %2e%2e%5c
+    /%252e%252e%252f/i, // Double encoded
   ];
 
   return traversalPatterns.some(pattern => pattern.test(input));
@@ -237,7 +239,13 @@ export function sanitizeText(
     let previous;
     do {
       previous = input;
-      input = input.replace(/\.\.[\/\\]/g, '');
+      input = input.replace(/\.\.[\/\\]/g, '')
+        .replace(/%2e%2e%2f/ig, '')
+        .replace(/%2e%2e\//ig, '')
+        .replace(/\.\.%2f/ig, '')
+        .replace(/\.\.%5c/ig, '')
+        .replace(/%2e%2e%5c/ig, '')
+        .replace(/%252e%252e%252f/ig, '');
     } while (input !== previous);
   }
 

--- a/trading-platform/app/lib/security/InputSanitizer.ts
+++ b/trading-platform/app/lib/security/InputSanitizer.ts
@@ -43,6 +43,14 @@ const DANGEROUS_EXTENSIONS = [
   '.jsp', '.asp', '.aspx', '.py', '.rb', '.pl',
 ];
 
+// Path Traversal Regex Components
+// Dot: literal dot, encoded dot, or double encoded dot
+const DOT_PATTERN = '(?:\\.|%2e|%252e)';
+// Slash: literal slash, backslash, encoded variants, or double encoded variants
+const SLASH_PATTERN = '(?:/|\\\\|%2f|%5c|%252f|%255c)';
+// Full pattern: .. followed by / or \ (handling all encoding permutations)
+const TRAVERSAL_REGEX = new RegExp(`${DOT_PATTERN}${DOT_PATTERN}${SLASH_PATTERN}`, 'ig');
+
 // ============================================================================
 // 基本サニタイズ関数
 // ============================================================================
@@ -137,18 +145,8 @@ export function detectXss(input: string): boolean {
  * パストラバーサルを検出
  */
 export function detectPathTraversal(input: string): boolean {
-  const traversalPatterns = [
-    /\.\.\//,        // ../
-    /\.\.\\/,        // ..\
-    /%2e%2e%2f/i,    // %2e%2e%2f
-    /%2e%2e\//i,     // %2e%2e/
-    /\.\.%2f/i,      // ..%2f
-    /\.\.%5c/i,      // ..%5c
-    /%2e%2e%5c/i,    // %2e%2e%5c
-    /%252e%252e%252f/i, // Double encoded
-  ];
-
-  return traversalPatterns.some(pattern => pattern.test(input));
+  // Use search() to avoid stateful behavior of global regex (lastIndex issues)
+  return input.search(TRAVERSAL_REGEX) !== -1;
 }
 
 /**
@@ -215,6 +213,18 @@ export function sanitizeText(
     input = input.trim();
   }
 
+  // パストラバーサル検出 (Run BEFORE HTML escaping to catch encoded slashes)
+  if (detectPathTraversal(input)) {
+    errors.push('Path traversal attempt detected');
+    // Apply replacement repeatedly to prevent bypass (e.g., ....// -> ../)
+    // Use the comprehensive regex to strip all variations
+    let previous;
+    do {
+      previous = input;
+      input = input.replace(TRAVERSAL_REGEX, '');
+    } while (input !== previous);
+  }
+
   // XSS検出
   if (detectXss(input)) {
     errors.push('Potential XSS pattern detected');
@@ -230,23 +240,6 @@ export function sanitizeText(
   if (detectSqlInjection(input)) {
     errors.push('Potential SQL injection pattern detected');
     input = escapeSql(input);
-  }
-
-  // パストラバーサル検出
-  if (detectPathTraversal(input)) {
-    errors.push('Path traversal attempt detected');
-    // Apply replacement repeatedly to prevent bypass (e.g., ....// -> ../)
-    let previous;
-    do {
-      previous = input;
-      input = input.replace(/\.\.[\/\\]/g, '')
-        .replace(/%2e%2e%2f/ig, '')
-        .replace(/%2e%2e\//ig, '')
-        .replace(/\.\.%2f/ig, '')
-        .replace(/\.\.%5c/ig, '')
-        .replace(/%2e%2e%5c/ig, '')
-        .replace(/%252e%252e%252f/ig, '');
-    } while (input !== previous);
   }
 
   // 最大長チェック


### PR DESCRIPTION
This PR addresses a security vulnerability where `sanitizeText` would detect but fail to strip URL-encoded path traversal sequences. 

The fix updates the sanitization loop to recursively remove these sequences, ensuring that the `sanitized` output is safe to use. This prevents potential path traversal attacks if the consuming code relies on the sanitized output without checking `isValid`.

Verified with unit tests covering standard, URL-encoded, mixed-encoded, and double-encoded traversal attempts.

---
*PR created automatically by Jules for task [3159482971282894093](https://jules.google.com/task/3159482971282894093) started by @kaenozu*