### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Insecure Default Admin Password Configuration

### DIFF
--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル

--- a/trading-platform/app/lib/__tests__/env-security.test.ts
+++ b/trading-platform/app/lib/__tests__/env-security.test.ts
@@ -37,4 +37,15 @@ describe('Environment Security', () => {
       jest.requireActual('../env');
     }).not.toThrow();
   });
+
+  it('should throw an error in production if ENABLE_DEFAULT_ADMIN is true and DEFAULT_ADMIN_PASSWORD is default', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ENABLE_DEFAULT_ADMIN = 'true';
+    process.env.DEFAULT_ADMIN_PASSWORD = 'admin123';
+    process.env.JWT_SECRET = 'secure-secret-that-is-very-long-and-random-32-chars';
+
+    expect(() => {
+      jest.requireActual('../env');
+    }).toThrow('CRITICAL SECURITY ERROR: You are running in production with the default admin password');
+  });
 });

--- a/trading-platform/app/lib/env.ts
+++ b/trading-platform/app/lib/env.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { devError } from '@/app/lib/utils/dev-logger';
 
 const DEFAULT_JWT_SECRET = 'demo-secret-must-be-at-least-32-chars-long';
+const DEFAULT_ADMIN_PASSWORD_VALUE = 'admin123';
 
 const envSchema = z.object({
   // Node Environment
@@ -21,7 +22,7 @@ const envSchema = z.object({
 
   // Initial Admin Config (Only if enabled)
   DEFAULT_ADMIN_EMAIL: z.string().email().default('admin@example.com'),
-  DEFAULT_ADMIN_PASSWORD: z.string().min(8).default('admin123'),
+  DEFAULT_ADMIN_PASSWORD: z.string().min(8).default(DEFAULT_ADMIN_PASSWORD_VALUE),
 
   // System Config
   NEXT_PUBLIC_API_URL: z.string().url().default('http://localhost:3000'),
@@ -55,6 +56,11 @@ if (!parsed.success) {
   // Security Check: Ensure production uses a secure secret
   if (parsed.data.NODE_ENV === 'production' && parsed.data.JWT_SECRET === DEFAULT_JWT_SECRET) {
     throw new Error('CRITICAL SECURITY ERROR: You are running in production with the default JWT_SECRET. Please set a secure JWT_SECRET environment variable.');
+  }
+
+  // Security Check: Ensure production does not use default admin password
+  if (parsed.data.NODE_ENV === 'production' && parsed.data.ENABLE_DEFAULT_ADMIN && parsed.data.DEFAULT_ADMIN_PASSWORD === DEFAULT_ADMIN_PASSWORD_VALUE) {
+    throw new Error('CRITICAL SECURITY ERROR: You are running in production with the default admin password. Please set a strong DEFAULT_ADMIN_PASSWORD environment variable.');
   }
 }
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Insecure Default Admin Password Configuration

🚨 Severity: CRITICAL
💡 Vulnerability: The application allowed `ENABLE_DEFAULT_ADMIN` to be enabled in production with the default weak password ('admin123'). This could allow unauthorized administrative access if the environment variable was not explicitly overridden.
🎯 Impact: Attackers could gain full administrative control of the trading platform if the default admin account was enabled in production without changing the password.
🔧 Fix:
- Implemented a mandatory check in `trading-platform/app/lib/env.ts`.
- The application now throws a critical error and refuses to start if `NODE_ENV=production` AND `ENABLE_DEFAULT_ADMIN=true` AND `DEFAULT_ADMIN_PASSWORD` is still the default.
- Extracted the default password to a constant for clarity and reuse.
✅ Verification:
- Added a new test case in `trading-platform/app/lib/__tests__/env-security.test.ts` that specifically verifies the error is thrown under these conditions.
- Ran existing security tests to ensure no regressions.


---
*PR created automatically by Jules for task [11139211573376131941](https://jules.google.com/task/11139211573376131941) started by @kaenozu*