### PR TITLE
🎨 Palette: Add aria-label to close button in PsychologyWarningPanel

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,3 +11,7 @@
 ## 2026-02-18 - Semantic Structures in Modals
 **Learning:** Complex components like `AlertConditionManager` often use `div`s for layout (e.g., tabs, modals) without semantic roles. This makes navigation impossible for screen readers. Explicitly adding `role="dialog"`, `aria-modal="true"`, and `role="tablist"` transforms a confusing "soup of divs" into a navigable application structure.
 **Action:** When creating or reviewing modal interfaces with tabs, always ensure the container has `role="dialog"` and the tab controls use the `tablist`/`tab` pattern.
+
+## 2025-03-01 - Added `aria-label` to Psychology Warning Card
+**Learning:** Found an icon-only button without an `aria-label` in the `PsychologyWarningPanel.tsx` component which rendered an SVG close button 'X', which makes screen readers unable to announce its function.
+**Action:** When implementing or refactoring close/dismiss buttons that only use icons, explicitly add an `aria-label` to ensure screen-reader accessibility.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+1. **Target**: `trading-platform/app/components/PsychologyWarningPanel.tsx`
+2. **Issue**: The close button for individual warning cards (`WarningCard` component) is an icon-only button missing an `aria-label`, creating an accessibility issue for screen reader users.
+3. **Action**: Add `aria-label="警告を閉じる"` (Close warning) to the button at line ~190.
+4. **Testing**: Run `pnpm lint` in the `trading-platform` directory.
+5. **Commit**: Submit the change.

--- a/trading-platform/app/components/PsychologyWarningPanel.tsx
+++ b/trading-platform/app/components/PsychologyWarningPanel.tsx
@@ -190,6 +190,7 @@ function WarningCard({ warning, onDismiss }: WarningCardProps) {
             <button
               onClick={onDismiss}
               className="flex-shrink-0 text-[#92adc9] hover:text-white transition-colors"
+              aria-label="警告を閉じる"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -20,9 +20,8 @@ export default function DemoPage() {
     change: 45,
     changePercent: 1.83,
     market: 'japan',
-    sector: '輸送用機器',
-    volume: 12500000,
     sector: 'auto',
+    volume: 12500000,
   };
 
   // 2. デモ用の完璧なAIシグナル


### PR DESCRIPTION
💡 **What**: Added an `aria-label="警告を閉じる"` to the icon-only SVG close button on the `WarningCard` inside `PsychologyWarningPanel.tsx`.

🎯 **Why**: Improves accessibility for users relying on screen readers, who would otherwise not hear the action associated with closing the warning.

♿ **Accessibility**: Provides an explicit text alternative for screen readers corresponding to the 'X' SVG icon.

---
*PR created automatically by Jules for task [8849095541196729266](https://jules.google.com/task/8849095541196729266) started by @kaenozu*