### PR TITLE
refactor: Remove any types in UI components (StockChart, PerformanceDashboard)

### DIFF
--- a/trading-platform/app/components/StockChart/StockChart.tsx
+++ b/trading-platform/app/components/StockChart/StockChart.tsx
@@ -14,6 +14,7 @@ import {
   CandlestickSeries,
   LineSeries,
   HistogramSeries,
+  SeriesMarker,
 } from 'lightweight-charts';
 import { OHLCV, Signal } from '@/app/types';
 import { SMA_CONFIG, GHOST_FORECAST, FORECAST_CONE } from '@/app/constants';
@@ -248,7 +249,7 @@ export const StockChart = memo(function StockChart({
     forecastLowerRef.current = forecastLower as unknown as ISeriesApi<'Line'>;
 
     // AI Confidence Markers (Beginner Friendly Visuals)
-    const markers: any[] = [];
+    const markers: SeriesMarker<Time>[] = [];
     if (signal && signal.confidence >= 60) {
       const time = data[data.length - 1].date as Time;
       const isBuy = signal.type === 'BUY';
@@ -276,7 +277,7 @@ export const StockChart = memo(function StockChart({
          });
       }
     }
-    (candleSeries as any).setMarkers(markers);
+    (candleSeries as unknown as { setMarkers: (markers: SeriesMarker<Time>[]) => void }).setMarkers(markers);
 
     const handleResize = () => {
       if (chartContainerRef.current) {
@@ -370,7 +371,7 @@ export const StockChart = memo(function StockChart({
     }
 
     // AI Confidence Markers
-    const markers: any[] = [];
+    const markers: SeriesMarker<Time>[] = [];
     if (signal && signal.confidence >= 60) {
       const time = data[data.length - 1].date as Time;
       const isBuy = signal.type === 'BUY';
@@ -396,7 +397,9 @@ export const StockChart = memo(function StockChart({
          });
       }
     }
-    (candleSeriesRef.current as any).setMarkers(markers);
+    if (candleSeriesRef.current) {
+      (candleSeriesRef.current as unknown as { setMarkers: (markers: SeriesMarker<Time>[]) => void }).setMarkers(markers);
+    }
 
   }, [data, signal, showVolume, showSMA, showBollinger, accuracyData, convertToLWCData, convertToVolumeData, calculateSMA, calculateBollingerBands]);
 

--- a/trading-platform/app/components/performance/PerformanceDashboard.tsx
+++ b/trading-platform/app/components/performance/PerformanceDashboard.tsx
@@ -4,6 +4,18 @@ import { globalCache } from '@/app/hooks/useCachedFetch';
 import { enhancedPredictionService } from '@/app/lib/services/enhanced-prediction-service';
 import { INTERVAL } from '@/app/constants/timing';
 
+interface PerformanceWithMemory extends Performance {
+  memory?: {
+    usedJSHeapSize: number;
+    totalJSHeapSize: number;
+  };
+}
+
+interface LayoutShiftEvent extends PerformanceEntry {
+  hadRecentInput: boolean;
+  value: number;
+}
+
 interface PerformanceMetrics {
   // レンダリング
   renderCount: number;
@@ -58,7 +70,7 @@ export function PerformanceDashboard() {
   
   const updateMetrics = useCallback(() => {
     // メモリ情報
-    const memory = (performance as any).memory;
+    const memory = (performance as unknown as PerformanceWithMemory).memory;
     
     // キャッシュ情報
     const cacheStats = globalCache.getStats();
@@ -108,8 +120,9 @@ export function PerformanceDashboard() {
     let clsValue = 0;
     const clsObserver = new PerformanceObserver((list) => {
       for (const entry of list.getEntries()) {
-        if (!(entry as any).hadRecentInput) {
-          clsValue += (entry as any).value;
+        const layoutEntry = entry as unknown as LayoutShiftEvent;
+        if (!layoutEntry.hadRecentInput) {
+          clsValue += layoutEntry.value;
         }
       }
       setMetrics(m => ({ ...m, cls: clsValue }));

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -20,9 +20,8 @@ export default function DemoPage() {
     change: 45,
     changePercent: 1.83,
     market: 'japan',
-    sector: '輸送用機器',
-    volume: 12500000,
     sector: 'auto',
+    volume: 12500000,
   };
 
   // 2. デモ用の完璧なAIシグナル


### PR DESCRIPTION
# Type Safety Refactoring - Phase 1

This PR tackles part of the `REFACTOR-002: 型安全性の向上` item from the Refactoring Roadmap by eliminating `any` type usage in key UI components.

## Changes Made:
- **`StockChart.tsx`**: Addressed warnings by properly typing `lightweight-charts` markers using `SeriesMarker<Time>[]` and utilizing structural type assertions instead of `(series as any).setMarkers()`.
- **`PerformanceDashboard.tsx`**: Addressed warnings regarding non-standard performance APIs by creating specific structural interfaces (`PerformanceWithMemory` and `LayoutShiftEvent`), ensuring type safety over Chrome's `.memory` and Cumulative Layout Shift `.hadRecentInput` values without resorting to `any`.
- **`demo/page.tsx`**: Fixed an existing TS compiler error caused by duplicate keys in an object literal.

## Validation:
- Successfully passed `npx tsc --noEmit` with zero errors.
- Handled UI `pnpm lint` and tests locally.

Part of roadmap item `REFACTOR-002: 型安全性の向上`.

---
*PR created automatically by Jules for task [11802400020986221101](https://jules.google.com/task/11802400020986221101) started by @kaenozu*