### PR TITLE
Refactor Phase 1: Improve Type Safety and eliminate `any` types

### DIFF
--- a/trading-platform/app/components/AlertConditionManager.tsx
+++ b/trading-platform/app/components/AlertConditionManager.tsx
@@ -172,7 +172,7 @@ export function AlertConditionManager() {
                   <select
                     value={newCondition.type}
                     aria-label="Condition Type"
-                    onChange={(e) => setNewCondition({ ...newCondition, type: e.target.value as any })}
+                    onChange={(e) => setNewCondition({ ...newCondition, type: e.target.value as 'price' | 'indicator' | 'portfolio' | 'risk' })}
                     className="w-full px-3 py-2 bg-gray-700 rounded text-white"
                   >
                     <option value="price">Price Alert</option>

--- a/trading-platform/app/components/StockChart/StockChart.tsx
+++ b/trading-platform/app/components/StockChart/StockChart.tsx
@@ -14,6 +14,7 @@ import {
   CandlestickSeries,
   LineSeries,
   HistogramSeries,
+  SeriesMarker,
 } from 'lightweight-charts';
 import { OHLCV, Signal } from '@/app/types';
 import { SMA_CONFIG, GHOST_FORECAST, FORECAST_CONE } from '@/app/constants';
@@ -248,7 +249,7 @@ export const StockChart = memo(function StockChart({
     forecastLowerRef.current = forecastLower as unknown as ISeriesApi<'Line'>;
 
     // AI Confidence Markers (Beginner Friendly Visuals)
-    const markers: any[] = [];
+    const markers: SeriesMarker<Time>[] = [];
     if (signal && signal.confidence >= 60) {
       const time = data[data.length - 1].date as Time;
       const isBuy = signal.type === 'BUY';
@@ -276,7 +277,7 @@ export const StockChart = memo(function StockChart({
          });
       }
     }
-    (candleSeries as any).setMarkers(markers);
+    (candleSeries as unknown as { setMarkers: (markers: SeriesMarker<Time>[]) => void }).setMarkers(markers);
 
     const handleResize = () => {
       if (chartContainerRef.current) {
@@ -370,7 +371,7 @@ export const StockChart = memo(function StockChart({
     }
 
     // AI Confidence Markers
-    const markers: any[] = [];
+    const markers: SeriesMarker<Time>[] = [];
     if (signal && signal.confidence >= 60) {
       const time = data[data.length - 1].date as Time;
       const isBuy = signal.type === 'BUY';
@@ -396,7 +397,7 @@ export const StockChart = memo(function StockChart({
          });
       }
     }
-    (candleSeriesRef.current as any).setMarkers(markers);
+    (candleSeriesRef.current as unknown as { setMarkers: (markers: SeriesMarker<Time>[]) => void }).setMarkers(markers);
 
   }, [data, signal, showVolume, showSMA, showBollinger, accuracyData, convertToLWCData, convertToVolumeData, calculateSMA, calculateBollingerBands]);
 

--- a/trading-platform/app/components/UnifiedIntelligenceCard.tsx
+++ b/trading-platform/app/components/UnifiedIntelligenceCard.tsx
@@ -26,7 +26,7 @@ export function UnifiedIntelligenceCard({ stock }: UnifiedIntelligenceCardProps)
       setIsLoading(true);
       try {
         // 1. 統合レポート生成
-        const result = await unifiedIntelligenceService.generateReport(stock.symbol, stock.market as any);
+        const result = await unifiedIntelligenceService.generateReport(stock.symbol, stock.market as 'japan' | 'usa');
         if (abortController.signal.aborted) return;
         setReport(result);
 

--- a/trading-platform/app/components/performance/PerformanceDashboard.tsx
+++ b/trading-platform/app/components/performance/PerformanceDashboard.tsx
@@ -4,6 +4,20 @@ import { globalCache } from '@/app/hooks/useCachedFetch';
 import { enhancedPredictionService } from '@/app/lib/services/enhanced-prediction-service';
 import { INTERVAL } from '@/app/constants/timing';
 
+interface MemoryInfo {
+  totalJSHeapSize: number;
+  usedJSHeapSize: number;
+}
+
+interface ExtendedPerformance extends Performance {
+  memory?: MemoryInfo;
+}
+
+interface LayoutShift extends PerformanceEntry {
+  hadRecentInput: boolean;
+  value: number;
+}
+
 interface PerformanceMetrics {
   // レンダリング
   renderCount: number;
@@ -58,7 +72,7 @@ export function PerformanceDashboard() {
   
   const updateMetrics = useCallback(() => {
     // メモリ情報
-    const memory = (performance as any).memory;
+    const memory = (performance as ExtendedPerformance).memory;
     
     // キャッシュ情報
     const cacheStats = globalCache.getStats();
@@ -108,8 +122,8 @@ export function PerformanceDashboard() {
     let clsValue = 0;
     const clsObserver = new PerformanceObserver((list) => {
       for (const entry of list.getEntries()) {
-        if (!(entry as any).hadRecentInput) {
-          clsValue += (entry as any).value;
+        if (!(entry as LayoutShift).hadRecentInput) {
+          clsValue += (entry as LayoutShift).value;
         }
       }
       setMetrics(m => ({ ...m, cls: clsValue }));

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -20,7 +20,6 @@ export default function DemoPage() {
     change: 45,
     changePercent: 1.83,
     market: 'japan',
-    sector: '輸送用機器',
     volume: 12500000,
     sector: 'auto',
   };

--- a/trading-platform/app/lib/dynamicImports.tsx
+++ b/trading-platform/app/lib/dynamicImports.tsx
@@ -155,7 +155,7 @@ export function prefetchComponent(componentPath: keyof typeof routeComponents) {
  * 重要度に応じて読み込み順序を制御
  */
 export function loadComponentWithPriority(
-  importFn: () => Promise<any>,
+  importFn: () => Promise<unknown>,
   priority: 'high' | 'low' = 'low'
 ) {
   if (priority === 'high') {

--- a/trading-platform/app/lib/performance-utils.ts
+++ b/trading-platform/app/lib/performance-utils.ts
@@ -234,7 +234,7 @@ export async function measurePerformanceAsync<T>(
  */
 export async function measureBatchPerformance(
   name: string,
-  operations: Array<{ name: string; fn: () => Promise<any> }>
+  operations: Array<{ name: string; fn: () => Promise<unknown> }>
 ): Promise<void> {
   const batchStart = performance.now();
 


### PR DESCRIPTION
Addresses Phase 1: REFACTOR-002 by significantly reducing the usage of `any` types throughout several components to improve type safety and maintainability.

**Refactor Details**:
1. **PerformanceDashboard**: Cast the global `performance` object into an `ExtendedPerformance` definition ensuring exact typings for the unstandardized `memory` API to avoid TS errors. Removed `any` for LayoutShift inputs.
2. **StockChart**: Imported and cast exactly matching types `SeriesMarker<Time>` from `lightweight-charts` rather than falling back to `any`.
3. **performance-utils & dynamicImports**: Upgraded Promise resolutions from `any` to `unknown` for strict type enforcement.
4. **UnifiedIntelligenceCard**: Replaced generic `any` with explicit argument typing `market as 'japan' | 'usa'` matching the service's expected argument definitions.
5. **AlertConditionManager**: Replaced an unverified `any` target type with expected `newCondition.type` definitions.
6. **demo/page**: Fixed TS multiple properties compilation error directly related to strict-mode checking.

The test failure `MLIntegrationService` is independent of this particular PR issue. The Next.js dev server couldn't compile fast enough to take screenshots due to large build times/timeouts.

---
*PR created automatically by Jules for task [10648739555116245817](https://jules.google.com/task/10648739555116245817) started by @kaenozu*