### PR TITLE
🎨 Palette: Fix OrderBook array mutation & a11y

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-03-08 - [Avoid In-Place Array Mutation]
+**Learning:** In React components, calling in-place mutation methods like `.reverse()` directly on arrays during the render phase (e.g., `{asks.reverse().map(...)}`) mutates the array in-place. This causes UI toggling/flickering bugs and is a common anti-pattern.
+**Action:** Always copy the array first before mutating it for rendering (e.g., `{[...asks].reverse()}`).

--- a/trading-platform/app/components/OrderBook.tsx
+++ b/trading-platform/app/components/OrderBook.tsx
@@ -35,7 +35,7 @@ export function OrderBook({ stock }: OrderBookProps) {
             </span>
         </div>
         <div className="flex-1 overflow-y-auto bg-[#101922]">
-            <table className="w-full text-xs tabular-nums border-collapse">
+            <table className="w-full text-xs tabular-nums border-collapse" aria-label="板情報">
             <thead className="sticky top-0 bg-[#141e27] text-[10px] text-[#92adc9] z-10">
                 <tr>
                 <th className="py-2 px-2 text-center font-medium w-1/3 border-b border-[#233648]">買数量</th>
@@ -44,7 +44,7 @@ export function OrderBook({ stock }: OrderBookProps) {
                 </tr>
             </thead>
             <tbody>
-                {asks.reverse().map((ask, i) => (
+                {[...asks].reverse().map((ask, i) => (
                     <tr key={`ask-${i}`} className="hover:bg-[#192633]/50">
                     <td className="py-0.5 px-2 text-right text-[#92adc9]"></td>
                     <td className="py-0.5 px-2 text-center text-red-500 font-medium">
@@ -54,6 +54,7 @@ export function OrderBook({ stock }: OrderBookProps) {
                         <span
                         className="absolute inset-y-0 left-0 bg-red-500/20"
                         style={{ width: `${Math.min(ask.size / 5, 100)}%` }}
+                        aria-hidden="true"
                         ></span>
                         <span className="relative z-10">{ask.size}</span>
                     </td>
@@ -73,6 +74,7 @@ export function OrderBook({ stock }: OrderBookProps) {
                         <span
                         className="absolute inset-y-0 right-0 bg-green-500/20"
                         style={{ width: `${Math.min(bid.size / 10, 100)}%` }}
+                        aria-hidden="true"
                         ></span>
                         <span className="relative z-10">{bid.size}</span>
                     </td>

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -20,7 +20,6 @@ export default function DemoPage() {
     change: 45,
     changePercent: 1.83,
     market: 'japan',
-    sector: '輸送用機器',
     volume: 12500000,
     sector: 'auto',
   };


### PR DESCRIPTION
💡 What:
1. Fixed an in-place array mutation bug during rendering in the `OrderBook` component. The `asks` array was mutated via `.reverse()` directly.
2. Added an `aria-label` to the main `OrderBook` table and `aria-hidden` attributes to visual volume bar background spans.

🎯 Why:
1. Calling `.reverse()` directly on an array during the render phase mutates the original array in place, leading to UI flickering bugs on subsequent renders.
2. Added `aria-label` to give the table better context for screen readers. Background visual bars shouldn't clutter the screen reader readout.

♿ Accessibility:
* Added `aria-label="板情報"` to the main OrderBook container table.
* Added `aria-hidden="true"` to visual color bars.

---
*PR created automatically by Jules for task [10882147682515078279](https://jules.google.com/task/10882147682515078279) started by @kaenozu*