### PR TITLE
🎨 Palette: Improve accessibility of cash balance editor in Header

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-10 - [Header Cash Edit Accessability]
+**Learning:** Found that custom interactive elements (like `div` with `onClick`) used to edit sensitive numbers like cash balance are completely inaccessible to keyboard users and lack semantic names.
+**Action:** Always add `role="button"`, `tabIndex={0}`, `aria-label`/`title`, a focus ring (`focus-visible:ring-2`), and an `onKeyDown` listener that catches `Enter` and `Space` when transforming non-interactive tags into clickable elements.

--- a/trading-platform/app/components/Header.tsx
+++ b/trading-platform/app/components/Header.tsx
@@ -158,7 +158,20 @@ export const Header = memo(function Header() {
         
         {/* Portfolio Stats */}
         <div className="hidden lg:flex gap-4 xl:gap-8 text-sm tabular-nums">
-          <div className="flex flex-col leading-tight group cursor-pointer relative" onClick={handleCashClick}>
+          <div
+            className="flex flex-col leading-tight group cursor-pointer relative rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+            onClick={handleCashClick}
+            role="button"
+            tabIndex={0}
+            aria-label="資金を編集"
+            title="資金を編集"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleCashClick();
+              }
+            }}
+          >
             <span className="text-[#92adc9] text-[10px] uppercase font-semibold tracking-wider flex items-center gap-1">
               資金
             </span>

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル


### PR DESCRIPTION
💡 **What:** Transformed the non-interactive `div` that triggers the cash editing state in the header into a fully accessible button element. Fixed a duplicate property bug in demo data.
🎯 **Why:** Previously, the cash amount in the Header could only be edited by clicking it with a mouse. Keyboard users and screen readers had no way to identify or interact with this functionality because it was a standard `div` element without semantic meaning or keyboard event listeners.
♿ **Accessibility:** Added proper `role="button"`, `tabIndex={0}`, keyboard support (`onKeyDown` for Enter/Space), screen reader text (`aria-label`), and clear visual feedback for keyboard navigation (`focus-visible` styles).

---
*PR created automatically by Jules for task [9106241927991757823](https://jules.google.com/task/9106241927991757823) started by @kaenozu*