### PR TITLE
refactor: resolve minor compilation and static analysis issues

### DIFF
--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -20,9 +20,8 @@ export default function DemoPage() {
     change: 45,
     changePercent: 1.83,
     market: 'japan',
-    sector: '輸送用機器',
-    volume: 12500000,
     sector: 'auto',
+    volume: 12500000,
   };
 
   // 2. デモ用の完璧なAIシグナル

--- a/trading-platform/app/types/api.ts
+++ b/trading-platform/app/types/api.ts
@@ -234,7 +234,7 @@ export function extractIntradayTimeSeries(
 ): Record<string, { '1. open': string; '2. high': string; '3. low': string; '4. close': string; '5. volume': string }> | undefined {
   for (const [key, value] of Object.entries(data)) {
     if (key === `Time Series (${interval})`) {
-      return (value || undefined) as any;
+      return (value || undefined) as Record<string, { '1. open': string; '2. high': string; '3. low': string; '4. close': string; '5. volume': string }> | undefined;
     }
   }
   return undefined;

--- a/trading-platform/app/workers/ml-prediction.worker.ts
+++ b/trading-platform/app/workers/ml-prediction.worker.ts
@@ -39,7 +39,7 @@ interface WorkerResponse {
 }
 
 let tfInstance: TensorFlowModule | null = null;
-let models: Map<string, LayersModel> = new Map();
+const models: Map<string, LayersModel> = new Map();
 
 async function loadTensorFlow(): Promise<TensorFlowModule> {
   if (tfInstance) return tfInstance;


### PR DESCRIPTION
This PR addresses minor code quality issues uncovered during routine refactoring and linting:

1. **Duplicate Object Keys**: Fixed a TypeScript compiler error (TS1117) in `app/demo/page.tsx` where the `mockStock` object had two `sector` keys.
2. **Type Safety**: Improved type safety in `app/types/api.ts` by replacing an `any` cast with a strict return type, moving closer to the REFACTOR-002 goal of zero `any` usages.
3. **Const Reassignment**: Fixed a `prefer-const` warning in `app/workers/ml-prediction.worker.ts` for the `models` Map.

These changes are low-risk and focus solely on bringing the codebase closer to strict static analysis compliance without altering business logic.

---
*PR created automatically by Jules for task [15309240765546423142](https://jules.google.com/task/15309240765546423142) started by @kaenozu*