### PR TITLE
⚡ Bolt: Optimize calculateATR performance in technical analysis utils

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2026-02-24 - [MACD Performance & Bug Fix]
 **Learning:** Generic `calculateEMA` utilities often enforce `price >= 0` (for financial data correctness), but derived indicators like MACD (Fast EMA - Slow EMA) can be negative. Reusing `calculateEMA` for the MACD Signal line caused the signal to vanish when MACD dipped below zero.
 **Action:** For derived indicators, use specialized inline calculations or validation logic that permits negative values, rather than reusing strict price-based utilities. Single-pass implementation also yielded a 50% performance boost by avoiding intermediate array allocations.
+
+## 2026-03-10 - Optimizing indicator calculations
+**Learning:** In V8 (Node.js/Chrome), when iterating over object arrays in hot loops (like OHLCV data for technical indicators), replacing loop-carried division operations by the `period` with multiplication by its pre-calculated inverse (`const invPeriod = 1 / period`) and caching previous iteration lookups (`data[i-1]` or `closes[i-1]`) significantly reduces overhead.
+**Action:** When working with math-heavy loops on large datasets (such as `calculateATR`), pre-calculate inverse constants to replace slow float division with float multiplication and cache array lookups in local variables when carrying them across loops.

--- a/trading-platform/app/lib/utils/technical-analysis.ts
+++ b/trading-platform/app/lib/utils/technical-analysis.ts
@@ -336,26 +336,36 @@ export function calculateATR(dataOrHighs: OHLCV[] | number[], periodOrLows?: num
   const length = isObjectArray ? data.length : highs.length;
   // Pre-allocate array for performance (~30% boost)
   const result: number[] = new Array(length);
+  if (length === 0) return result;
+
   let sum = 0;
   let validCount = 0;
 
+  // Pre-calculated inverse for performance
+  const invPeriod = 1 / period;
+  const periodMinus1 = period - 1;
+
   if (isObjectArray) {
+    let prevClose = 0; // Cache previous close
+
     // Initial loop
-    for (let i = 0; i < length && i < period; i++) {
-      const currentHigh = data[i].high;
-      const currentLow = data[i].low;
+    const initialLimit = Math.min(length, period);
+    for (let i = 0; i < initialLimit; i++) {
+      const curr = data[i];
+      const currentHigh = curr.high;
+      const currentLow = curr.low;
       let tr = NaN;
 
       if (i === 0) {
         tr = currentHigh - currentLow;
       } else {
-        const prevClose = data[i - 1].close;
         tr = Math.max(
           currentHigh - currentLow,
           Math.abs(currentHigh - prevClose),
           Math.abs(currentLow - prevClose)
         );
       }
+      prevClose = curr.close;
 
       if (!isNaN(tr)) {
         sum += tr;
@@ -364,31 +374,38 @@ export function calculateATR(dataOrHighs: OHLCV[] | number[], periodOrLows?: num
       result[i] = NaN;
 
       if (i === period - 1) {
-        result[i] = validCount === period ? sum / period : NaN;
+        result[i] = validCount === period ? sum * invPeriod : NaN;
       }
     }
 
     // Remaining loop
-    for (let i = period; i < length; i++) {
-      const currentHigh = data[i].high;
-      const currentLow = data[i].low;
-      const prevClose = data[i - 1].close;
-      const tr = Math.max(
-        currentHigh - currentLow,
-        Math.abs(currentHigh - prevClose),
-        Math.abs(currentLow - prevClose)
-      );
+    if (length > period) {
+      for (let i = period; i < length; i++) {
+        const curr = data[i];
+        const currentHigh = curr.high;
+        const currentLow = curr.low;
 
-      const prevResult = result[i - 1];
-      if (!isNaN(tr) && !isNaN(prevResult)) {
-        result[i] = (prevResult * (period - 1) + tr) / period;
-      } else {
-        result[i] = NaN;
+        const tr = Math.max(
+          currentHigh - currentLow,
+          Math.abs(currentHigh - prevClose),
+          Math.abs(currentLow - prevClose)
+        );
+        prevClose = curr.close;
+
+        const prevResult = result[i - 1];
+        if (!isNaN(tr) && !isNaN(prevResult)) {
+          result[i] = (prevResult * periodMinus1 + tr) * invPeriod;
+        } else {
+          result[i] = NaN;
+        }
       }
     }
   } else {
+    let prevClose = 0; // Cache previous close
+
     // Initial loop
-    for (let i = 0; i < length && i < period; i++) {
+    const initialLimit = Math.min(length, period);
+    for (let i = 0; i < initialLimit; i++) {
       const currentHigh = highs[i];
       const currentLow = lows[i];
       let tr = NaN;
@@ -396,13 +413,13 @@ export function calculateATR(dataOrHighs: OHLCV[] | number[], periodOrLows?: num
       if (i === 0) {
         tr = currentHigh - currentLow;
       } else {
-        const prevClose = closes[i - 1];
         tr = Math.max(
           currentHigh - currentLow,
           Math.abs(currentHigh - prevClose),
           Math.abs(currentLow - prevClose)
         );
       }
+      prevClose = closes[i];
 
       if (!isNaN(tr)) {
         sum += tr;
@@ -411,27 +428,29 @@ export function calculateATR(dataOrHighs: OHLCV[] | number[], periodOrLows?: num
       result[i] = NaN;
 
       if (i === period - 1) {
-        result[i] = validCount === period ? sum / period : NaN;
+        result[i] = validCount === period ? sum * invPeriod : NaN;
       }
     }
 
     // Remaining loop
-    for (let i = period; i < length; i++) {
-      const currentHigh = highs[i];
-      const currentLow = lows[i];
-      const prevClose = closes[i - 1];
+    if (length > period) {
+      for (let i = period; i < length; i++) {
+        const currentHigh = highs[i];
+        const currentLow = lows[i];
 
-      const tr = Math.max(
-        currentHigh - currentLow,
-        Math.abs(currentHigh - prevClose),
-        Math.abs(currentLow - prevClose)
-      );
+        const tr = Math.max(
+          currentHigh - currentLow,
+          Math.abs(currentHigh - prevClose),
+          Math.abs(currentLow - prevClose)
+        );
+        prevClose = closes[i];
 
-      const prevResult = result[i - 1];
-      if (!isNaN(tr) && !isNaN(prevResult)) {
-        result[i] = (prevResult * (period - 1) + tr) / period;
-      } else {
-        result[i] = NaN;
+        const prevResult = result[i - 1];
+        if (!isNaN(tr) && !isNaN(prevResult)) {
+          result[i] = (prevResult * periodMinus1 + tr) * invPeriod;
+        } else {
+          result[i] = NaN;
+        }
       }
     }
   }


### PR DESCRIPTION
💡 What: Refactored the `calculateATR` function in `trading-platform/app/lib/utils/technical-analysis.ts` to replace division with multiplication by a pre-calculated inverse and to cache `prevClose` within the loop scope.
🎯 Why: In V8/Node environments, repeated float division is slower than float multiplication. Additionally, retrieving `closes[i-1]` or `data[i-1].close` directly from an array in each loop iteration introduces unnecessary indexing overhead that can be avoided by caching it locally.
📊 Impact: Expected to yield ~10% performance improvement in the ATR calculation loop.
🔬 Measurement: Verify by running `pnpm test trading-platform/app/lib/__tests__/utils.test.ts` to ensure functionally identical results. Benchmarked internally via `ts-node`.

---
*PR created automatically by Jules for task [318285426493269987](https://jules.google.com/task/318285426493269987) started by @kaenozu*