### PR TITLE
Fix duplicate property in demo page mock data

### DIFF
--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル


### PR DESCRIPTION
This fixes a TypeScript compilation error in `trading-platform/app/demo/page.tsx` where the `mockStock` object literal had two `sector` properties.

---
*PR created automatically by Jules for task [10546951702653892165](https://jules.google.com/task/10546951702653892165) started by @kaenozu*