### PR TITLE
Refactor: Enforce strict typings by removing `as any` from tests

### DIFF
--- a/trading-platform/app/lib/__tests__/BacktestService.test.ts
+++ b/trading-platform/app/lib/__tests__/BacktestService.test.ts
@@ -180,27 +180,27 @@ describe('BacktestService', () => {
 
   describe('filterByDateRange', () => {
     it('should filter data by start date only', () => {
-      const result = (service as any).filterByDateRange(mockData, '2024-01-20', undefined);
+      const result = (service as unknown as { filterByDateRange: (data: OHLCV[], startDate?: string, endDate?: string) => OHLCV[] }).filterByDateRange(mockData, '2024-01-20', undefined);
       expect(result.length).toBeLessThan(mockData.length);
     });
 
     it('should filter data by end date only', () => {
-      const result = (service as any).filterByDateRange(mockData, undefined, '2024-01-50');
+      const result = (service as unknown as { filterByDateRange: (data: OHLCV[], startDate?: string, endDate?: string) => OHLCV[] }).filterByDateRange(mockData, undefined, '2024-01-50');
       expect(result.length).toBeLessThan(mockData.length);
     });
 
     it('should filter data by both start and end dates', () => {
-      const result = (service as any).filterByDateRange(mockData, '2024-01-20', '2024-01-50');
+      const result = (service as unknown as { filterByDateRange: (data: OHLCV[], startDate?: string, endDate?: string) => OHLCV[] }).filterByDateRange(mockData, '2024-01-20', '2024-01-50');
       expect(result.length).toBeGreaterThan(0);
     });
 
     it('should return all data if no dates specified', () => {
-      const result = (service as any).filterByDateRange(mockData, undefined, undefined);
+      const result = (service as unknown as { filterByDateRange: (data: OHLCV[], startDate?: string, endDate?: string) => OHLCV[] }).filterByDateRange(mockData, undefined, undefined);
       expect(result).toEqual(mockData);
     });
 
     it('should handle empty data array', () => {
-      const result = (service as any).filterByDateRange([], '2024-01-01', '2024-01-31');
+      const result = (service as unknown as { filterByDateRange: (data: OHLCV[], startDate?: string, endDate?: string) => OHLCV[] }).filterByDateRange([], '2024-01-01', '2024-01-31');
       expect(result).toEqual([]);
     });
   });
@@ -215,6 +215,29 @@ describe('BacktestService', () => {
       volume: 1000000,
     };
 
+    interface BacktestPosition {
+      symbol: string;
+      type: 'LONG' | 'SHORT';
+      quantity: number;
+      entryPrice: number;
+      entryDate: string;
+      value: number;
+    }
+
+    interface BacktestConfig {
+      initialCapital: number;
+      commission: number;
+      slippage: number;
+    }
+
+    type EvaluateTradeFn = (
+      signal: Signal,
+      currentCandle: OHLCV,
+      currentPosition: BacktestPosition | null,
+      capital: number,
+      config: BacktestConfig
+    ) => { type: 'ENTER_LONG' | 'ENTER_SHORT' | 'EXIT_LONG' | 'EXIT_SHORT', signal: Signal } | null;
+
     it('should return ENTER_LONG for BUY signal with sufficient confidence', () => {
       const signal: Signal = {
         type: 'BUY',
@@ -225,7 +248,7 @@ describe('BacktestService', () => {
         takeProfit: 110,
       };
 
-      const result = (service as any).evaluateTrade(
+      const result = (service as unknown as { evaluateTrade: EvaluateTradeFn }).evaluateTrade(
         signal,
         mockCandle,
         null,
@@ -246,7 +269,7 @@ describe('BacktestService', () => {
         takeProfit: 90,
       };
 
-      const result = (service as any).evaluateTrade(
+      const result = (service as unknown as { evaluateTrade: EvaluateTradeFn }).evaluateTrade(
         signal,
         mockCandle,
         null,
@@ -267,7 +290,7 @@ describe('BacktestService', () => {
         takeProfit: 110,
       };
 
-      const result = (service as any).evaluateTrade(
+      const result = (service as unknown as { evaluateTrade: EvaluateTradeFn }).evaluateTrade(
         signal,
         mockCandle,
         null,
@@ -279,9 +302,9 @@ describe('BacktestService', () => {
     });
 
     it('should return EXIT_LONG when holding LONG and get SELL signal', () => {
-      const longPosition = {
+      const longPosition: BacktestPosition = {
         symbol: 'AAPL',
-        type: 'LONG' as const,
+        type: 'LONG',
         quantity: 10,
         entryPrice: 100,
         entryDate: '2024-01-10',
@@ -297,7 +320,7 @@ describe('BacktestService', () => {
         takeProfit: 90,
       };
 
-      const result = (service as any).evaluateTrade(
+      const result = (service as unknown as { evaluateTrade: EvaluateTradeFn }).evaluateTrade(
         sellSignal,
         mockCandle,
         longPosition,
@@ -309,9 +332,9 @@ describe('BacktestService', () => {
     });
 
     it('should return EXIT_SHORT when holding SHORT and get BUY signal', () => {
-      const shortPosition = {
+      const shortPosition: BacktestPosition = {
         symbol: 'AAPL',
-        type: 'SHORT' as const,
+        type: 'SHORT',
         quantity: 10,
         entryPrice: 100,
         entryDate: '2024-01-10',
@@ -327,7 +350,7 @@ describe('BacktestService', () => {
         takeProfit: 110,
       };
 
-      const result = (service as any).evaluateTrade(
+      const result = (service as unknown as { evaluateTrade: EvaluateTradeFn }).evaluateTrade(
         buySignal,
         mockCandle,
         shortPosition,

--- a/trading-platform/app/lib/__tests__/TEST_PATTERNS.md
+++ b/trading-platform/app/lib/__tests__/TEST_PATTERNS.md
@@ -51,7 +51,7 @@ describe('ServiceName', () => {
     });
 
     it('should handle edge case: invalid input', () => {
-      expect(() => service.methodName(null as any)).toThrow();
+      expect(() => service.methodName(null as unknown as ExpectedType)).toThrow();
     });
   });
 });

--- a/trading-platform/app/lib/__tests__/VolumeAnalysis.test.ts
+++ b/trading-platform/app/lib/__tests__/VolumeAnalysis.test.ts
@@ -284,9 +284,9 @@ describe('VolumeAnalysisService', () => {
   describe('Error Handling', () => {
     it('should handle null or undefined data gracefully', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(() => service.calculateVolumeProfile(null as any)).toThrow();
+      expect(() => service.calculateVolumeProfile(null as unknown as OHLCV[])).toThrow();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(() => service.calculateVolumeProfile(undefined as any)).toThrow();
+      expect(() => service.calculateVolumeProfile(undefined as unknown as OHLCV[])).toThrow();
     });
 
     it('should handle data with invalid numbers', () => {

--- a/trading-platform/app/lib/__tests__/auth-security.test.ts
+++ b/trading-platform/app/lib/__tests__/auth-security.test.ts
@@ -2,6 +2,7 @@
 import { verifyAuthToken } from '../auth';
 import jwt from 'jsonwebtoken';
 import { resetConfig } from '../config/env-validator';
+import { NextRequest } from 'next/server';
 
 class MockNextRequest {
   headers: Map<string, string>;
@@ -38,7 +39,7 @@ describe.skip('Authentication Security', () => {
     
     // verifyAuthToken calls getConfig() internally
     expect(() => {
-      verifyAuthToken(new MockNextRequest('http://localhost:3000/api/test') as any);
+      verifyAuthToken(new MockNextRequest('http://localhost:3000/api/test') as unknown as NextRequest);
     }).toThrow('JWT_SECRET must be at least 32 characters');
   });
 

--- a/trading-platform/app/lib/__tests__/auth.test.ts
+++ b/trading-platform/app/lib/__tests__/auth.test.ts
@@ -47,7 +47,7 @@ describe.skip('Authentication Module', () => {
 
     it('should include correct payload in token', () => {
       const token = generateAuthToken(validUserId, validUsername);
-      const decoded = jwt.decode(token) as any;
+      const decoded = jwt.decode(token) as jwt.JwtPayload;
       
       expect(decoded.userId).toBe(validUserId);
       expect(decoded.username).toBe(validUsername);
@@ -205,7 +205,7 @@ describe.skip('Authentication Module', () => {
   describe('Token expiration', () => {
     it('should include expiration claim in token', () => {
       const token = generateAuthToken(validUserId);
-      const decoded = jwt.decode(token) as any;
+      const decoded = jwt.decode(token) as jwt.JwtPayload;
 
       expect(decoded.exp).toBeDefined();
       expect(typeof decoded.exp).toBe('number');
@@ -214,7 +214,7 @@ describe.skip('Authentication Module', () => {
 
     it('should include issued at claim in token', () => {
       const token = generateAuthToken(validUserId);
-      const decoded = jwt.decode(token) as any;
+      const decoded = jwt.decode(token) as jwt.JwtPayload;
 
       expect(decoded.iat).toBeDefined();
       expect(typeof decoded.iat).toBe('number');

--- a/trading-platform/app/lib/__tests__/chart-utils.test.ts
+++ b/trading-platform/app/lib/__tests__/chart-utils.test.ts
@@ -97,7 +97,7 @@ describe('calculateChartMinMax', () => {
     ];
     const indicators = {
       sma: [NaN, 85, NaN],
-      upper: [125, null as any, undefined as any],
+      upper: [125, null as unknown as number, undefined as unknown as number],
     };
     const result = calculateChartMinMax(data, indicators);
     expect(result).toEqual({ min: 85, max: 125 });

--- a/trading-platform/app/lib/__tests__/forecastAccuracy.test.ts
+++ b/trading-platform/app/lib/__tests__/forecastAccuracy.test.ts
@@ -270,7 +270,7 @@ describe('ForecastAccuracyService', () => {
   describe('Error Handling', () => {
     it('should handle null predictions gracefully', () => {
       expect(() => {
-        forecastAccuracyService.calculateAccuracy(null as any, []);
+        forecastAccuracyService.calculateAccuracy(null as unknown as Prediction[], []);
       }).toThrow();
     });
 

--- a/trading-platform/app/types/api.ts
+++ b/trading-platform/app/types/api.ts
@@ -234,7 +234,7 @@ export function extractIntradayTimeSeries(
 ): Record<string, { '1. open': string; '2. high': string; '3. low': string; '4. close': string; '5. volume': string }> | undefined {
   for (const [key, value] of Object.entries(data)) {
     if (key === `Time Series (${interval})`) {
-      return (value || undefined) as any;
+      return (value || undefined) as Record<string, { '1. open': string; '2. high': string; '3. low': string; '4. close': string; '5. volume': string }> | undefined;
     }
   }
   return undefined;


### PR DESCRIPTION
This submission addresses the codebase refactoring request by removing several occurrences of the `as any` type assertion found within the `trading-platform/app/lib/__tests__/` directory. 

Historically, `as any` was being used as a shortcut to test invalid inputs (like `null`) or access private methods. This commit replaces those instances with stricter type constraints (e.g., `as unknown as Type`) or custom scoped interfaces, aligning the tests with the project's strict typing goal (REFACTOR-002). I also patched an instance of `as any` in `app/types/api.ts`.

Pre-commit validation steps (tests, linting, code review) have been successfully completed.

---
*PR created automatically by Jules for task [16921378144581114899](https://jules.google.com/task/16921378144581114899) started by @kaenozu*