### PR TITLE
fix: Remove duplicate object literal property `sector` in demo mock data

### DIFF
--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -20,7 +20,6 @@ export default function DemoPage() {
     change: 45,
     changePercent: 1.83,
     market: 'japan',
-    sector: '輸送用機器',
     volume: 12500000,
     sector: 'auto',
   };


### PR DESCRIPTION
**Problem:**
The TypeScript compiler (`tsc --noEmit`) and CI build step were failing due to a duplicated property in an object literal in `trading-platform/app/demo/page.tsx`. Specifically, `mockStock` defined the `sector` key twice.

**Solution:**
Removed the duplicate `sector: '輸送用機器'` entry, keeping only `sector: 'auto'`. Since duplicate keys in standard JavaScript object literals silently overwrite earlier keys, this does not change runtime behavior but correctly resolves the strict typechecking error.

**Verification:**
- Ran `npx tsc --noEmit` and confirmed it passes without TS1117 errors.
- Ran `npm run lint` successfully.
- Ran unit tests.

---
*PR created automatically by Jules for task [5600473836251874452](https://jules.google.com/task/5600473836251874452) started by @kaenozu*