### PR TITLE
fix: remove duplicate sector property from mockStock

### DIFF
--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル


### PR DESCRIPTION
This commit fixes a TypeScript error (TS1117) in `trading-platform/app/demo/page.tsx` where the `mockStock` object literal had multiple properties with the same name (`sector`).

It removes the duplicate `sector: 'auto'` to maintain the localized Japanese `sector: '輸送用機器'`.
This allows `tsc --noEmit` and quality gating processes to pass without regressions on tests.

---
*PR created automatically by Jules for task [675178141758092203](https://jules.google.com/task/675178141758092203) started by @kaenozu*