### PR TITLE
Refactor: Implement ErrorToast and Unify UI Error Handling (REFACTOR-008)

### DIFF
--- a/trading-platform/app/components/ErrorBoundary.tsx
+++ b/trading-platform/app/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle, RefreshCcw, Home, Bug, Copy, CheckCircle } from 'lucide-react';
 import { ANIMATION } from '@/app/constants/timing';
+import { showErrorToast } from '@/app/components/ErrorToast';
 import {
   NetworkError,
   ValidationError,
@@ -178,6 +179,9 @@ export class ErrorBoundary extends Component<Props, State> {
     // 統一エラーシステムでログ出力
     const appError = isAppError(error) ? error : handleError(error, name || 'ErrorBoundary');
     
+    // UIへのトースト通知
+    showErrorToast(appError, name || 'ErrorBoundary');
+
     if (process.env.NODE_ENV !== 'production') {
       console.error(`ErrorBoundary caught an error in ${name || 'component'}:`, {
         error: appError.toJSON(),

--- a/trading-platform/app/components/ErrorToast.tsx
+++ b/trading-platform/app/components/ErrorToast.tsx
@@ -1,0 +1,42 @@
+import { toast } from 'sonner';
+import { isAppError, handleError, getUserErrorMessage } from '@/app/lib/errors';
+import type { ErrorSeverity } from '@/app/lib/errors';
+
+/**
+ * カスタムエラーを解析し、sonnerのtoastで表示する
+ */
+export function showErrorToast(error: unknown, context: string = 'App'): void {
+  // unknownエラーをAppErrorとしてパース
+  const appError = isAppError(error) ? error : handleError(error, context);
+  const userMessage = getUserErrorMessage(appError);
+
+  // 重大度に応じた設定
+  const severity = appError.severity as ErrorSeverity;
+
+  const toastOptions = {
+    duration: severity === 'critical' ? 10000 : 5000,
+  };
+
+  if (severity === 'critical') {
+    toast.error(appError.name || '重大なエラー', {
+      description: userMessage,
+      ...toastOptions,
+    });
+  } else if (severity === 'high') {
+    toast.error(appError.name || 'エラー', {
+      description: userMessage,
+      ...toastOptions,
+    });
+  } else if (severity === 'medium') {
+    toast.warning(appError.name || '警告', {
+      description: userMessage,
+      ...toastOptions,
+    });
+  } else {
+    // low, info etc.
+    toast.info(appError.name || '通知', {
+      description: userMessage,
+      ...toastOptions,
+    });
+  }
+}

--- a/trading-platform/app/components/OrderPanel.tsx
+++ b/trading-platform/app/components/OrderPanel.tsx
@@ -6,6 +6,7 @@ import { useOrderEntry } from '@/app/hooks/useOrderEntry';
 import { RiskSettingsPanel } from './RiskSettingsPanel';
 import { usePortfolioStore } from '@/app/store/portfolioStore';
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { showErrorToast } from '@/app/components/ErrorToast';
 
 /**
  * メッセージ定数
@@ -161,6 +162,7 @@ export function OrderPanel({ stock, currentPrice, ohlcv = [] }: OrderPanelProps)
       await handleOrder();
     } catch (error) {
       console.error('Order execution failed:', error);
+      showErrorToast(error, 'OrderPanel');
     } finally {
       setIsProcessing(false);
     }

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル

--- a/trading-platform/app/layout.tsx
+++ b/trading-platform/app/layout.tsx
@@ -44,6 +44,7 @@ import { Navigation } from "@/app/components/Navigation";
 import { UserExperienceEnhancements } from "@/app/components/UserExperienceEnhancements";
 import { StoreHydration } from "@/app/components/StoreHydration";
 import { Providers } from "@/app/providers";
+import { Toaster } from "sonner";
 
 export default function RootLayout({
   children,
@@ -98,6 +99,7 @@ export default function RootLayout({
               </MonitoringProvider>
             </MLProvider>
           </ThemeProvider>
+          <Toaster theme="dark" position="bottom-right" richColors />
         </Providers>
       </body>
     </html>

--- a/trading-platform/app/types/api.ts
+++ b/trading-platform/app/types/api.ts
@@ -234,7 +234,7 @@ export function extractIntradayTimeSeries(
 ): Record<string, { '1. open': string; '2. high': string; '3. low': string; '4. close': string; '5. volume': string }> | undefined {
   for (const [key, value] of Object.entries(data)) {
     if (key === `Time Series (${interval})`) {
-      return (value || undefined) as any;
+      return value as Record<string, { '1. open': string; '2. high': string; '3. low': string; '4. close': string; '5. volume': string }> | undefined;
     }
   }
   return undefined;

--- a/trading-platform/app/workers/indicator.worker.ts
+++ b/trading-platform/app/workers/indicator.worker.ts
@@ -1,6 +1,6 @@
 import { calculateIndicatorsSync } from './indicator-logic';
 
-const ctx: Worker = self as any;
+const ctx: Worker = self as unknown as Worker;
 
 /**
  * テクニカル指標計算 Web Worker

--- a/trading-platform/app/workers/prediction-analysis.worker.ts
+++ b/trading-platform/app/workers/prediction-analysis.worker.ts
@@ -9,7 +9,7 @@ import { integratedPredictionService } from '@/app/domains/prediction/services/i
 import { Stock, OHLCV } from '@/app/types';
 
 // Web Worker message handling
-const ctx: Worker = self as any;
+const ctx: Worker = self as unknown as Worker;
 
 ctx.onmessage = async (event: MessageEvent) => {
   const { requestId, stock, data, indexData } = event.data;


### PR DESCRIPTION
This PR implements the missing UI feedback loop for **REFACTOR-008 (Error Handling)**. It leverages the existing unified `app/lib/errors` ecosystem by introducing a global `sonner` toast component (`ErrorToast`). Now, when an `AppError` is thrown (e.g., inside `OrderPanel` or caught by `ErrorBoundary`), it's parsed and presented with a structured toast notification instead of just failing silently or logging to the console.

Additionally, this PR fixes a few `any` types and an object literal key duplication (`sector` in `app/demo/page.tsx`) to progress on **REFACTOR-002 (Strict Typing)**.

---
*PR created automatically by Jules for task [9189669042330551364](https://jules.google.com/task/9189669042330551364) started by @kaenozu*