### PR TITLE
🎨 Palette: Add ARIA labels to DashboardCustomizer icon-only buttons

### DIFF
--- a/trading-platform/app/components/DashboardCustomizer.tsx
+++ b/trading-platform/app/components/DashboardCustomizer.tsx
@@ -85,6 +85,7 @@ export function DashboardCustomizer() {
             <button
               onClick={() => setIsOpen(false)}
               className="text-gray-400 hover:text-white"
+              aria-label="Close"
             >
               ✕
             </button>
@@ -168,6 +169,7 @@ export function DashboardCustomizer() {
                       <button
                         onClick={() => deleteLayout(layout.id)}
                         className="p-2 hover:bg-gray-700 rounded text-red-400"
+                        aria-label={`Delete layout ${layout.name}`}
                       >
                         <Trash2 className="w-4 h-4" />
                       </button>
@@ -203,6 +205,7 @@ export function DashboardCustomizer() {
                         key={widget.type}
                         onClick={() => handleAddWidget(widget.type)}
                         className="p-2 bg-gray-700 hover:bg-gray-600 rounded text-left text-sm"
+                        aria-label={`Add ${widget.label} widget`}
                       >
                         {widget.label}
                       </button>
@@ -242,6 +245,7 @@ export function DashboardCustomizer() {
                             currentLayoutId && toggleWidgetVisibility(currentLayoutId, widget.id)
                           }
                           className="p-2 hover:bg-gray-700 rounded"
+                          aria-label={`${widget.visible ? 'Hide' : 'Show'} ${widget.title} widget`}
                         >
                           {widget.visible ? (
                             <Eye className="w-4 h-4 text-green-500" />
@@ -252,6 +256,7 @@ export function DashboardCustomizer() {
                         <button
                           onClick={() => currentLayoutId && removeWidget(currentLayoutId, widget.id)}
                           className="p-2 hover:bg-gray-700 rounded text-red-400"
+                          aria-label={`Remove ${widget.title} widget`}
                         >
                           <Trash2 className="w-4 h-4" />
                         </button>

--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -20,9 +20,8 @@ export default function DemoPage() {
     change: 45,
     changePercent: 1.83,
     market: 'japan',
-    sector: '輸送用機器',
-    volume: 12500000,
     sector: 'auto',
+    volume: 12500000,
   };
 
   // 2. デモ用の完璧なAIシグナル


### PR DESCRIPTION
### 💡 What
Added descriptive `aria-label` attributes to the icon-only `<button>` elements in `trading-platform/app/components/DashboardCustomizer.tsx`.

### 🎯 Why
Icon-only buttons rely on visual cues (like the `Lucide` icons for trash, eye, close) to convey their purpose. Screen readers cannot interpret these visuals alone, making the buttons completely inaccessible to users who rely on assistive technologies. Adding dynamic, contextual `aria-labels` explicitly defines the purpose of each button, significantly improving the component's accessibility and usability.

### ♿ Accessibility
- Added `aria-label="Close"` to the main modal close button.
- Added dynamic `aria-label`s to the layout deletion buttons specifying which layout is being deleted.
- Added dynamic `aria-label`s to the add widget buttons indicating which widget type will be added.
- Added state-aware `aria-label`s to the widget visibility toggles (e.g., "Show Price Chart widget" / "Hide Price Chart widget").
- Added dynamic `aria-label`s to the widget removal buttons specifying which widget is being removed.

---
*PR created automatically by Jules for task [7850035807150889118](https://jules.google.com/task/7850035807150889118) started by @kaenozu*