### PR TITLE
fix(ui): resolve TS1117 duplicate property error in demo page

### DIFF
--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -20,7 +20,6 @@ export default function DemoPage() {
     change: 45,
     changePercent: 1.83,
     market: 'japan',
-    sector: '輸送用機器',
     volume: 12500000,
     sector: 'auto',
   };


### PR DESCRIPTION
## What
Removed the duplicate `sector` key from the `mockStock` object in `trading-platform/app/demo/page.tsx`.

## Why
TypeScript strict mode correctly identifies duplicate keys in object literals as a TS1117 error. This issue was preventing the project from compiling successfully (`tsc --noEmit`).

## Impact
- **TypeScript:** Resolves the TS1117 compilation error.
- **CI/CD:** Unblocks the build validation pipeline (`npx tsc --noEmit` now passes).
- **Functionality:** No behavior changes; the object structure is unchanged since the last defined property would have overwritten the previous one anyway.

## Measurement
Ran `npx tsc --noEmit` and `pnpm lint` in `trading-platform` to verify the error is completely resolved without introducing any regressions.

---
*PR created automatically by Jules for task [15998500004474266961](https://jules.google.com/task/15998500004474266961) started by @kaenozu*