### PR TITLE
fix: Remove duplicate property `sector` in mockStock object literal

### DIFF
--- a/trading-platform/app/demo/page.tsx
+++ b/trading-platform/app/demo/page.tsx
@@ -22,7 +22,6 @@ export default function DemoPage() {
     market: 'japan',
     sector: '輸送用機器',
     volume: 12500000,
-    sector: 'auto',
   };
 
   // 2. デモ用の完璧なAIシグナル


### PR DESCRIPTION
# Description
Removed the duplicate `sector` property inside the `mockStock` object in `trading-platform/app/demo/page.tsx`.

## Why this change is necessary
During a full codebase review and compilation check (`npx tsc --noEmit`), an error was detected:
`app/demo/page.tsx(25,5): error TS1117: An object literal cannot have multiple properties with the same name.`

The `mockStock` object literal was declaring the `sector` property twice (`sector: '輸送用機器'` and `sector: 'auto'`).

## Impact
This change resolves the TypeScript compilation failure, making the build cleaner and ensuring type checking passes correctly.

## Verification
- Applied patch to `trading-platform/app/demo/page.tsx`.
- Ran `grep -A 10 "mockStock: Stock" trading-platform/app/demo/page.tsx` to visually confirm the fix.
- Re-ran `cd trading-platform && npm run lint && npx tsc --noEmit && npm run test`. The TS1117 error is completely gone. Tested and linters ran normally with no new errors.

---
*PR created automatically by Jules for task [9487483505817877359](https://jules.google.com/task/9487483505817877359) started by @kaenozu*